### PR TITLE
CSB-432 Use community version of camel-report-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot</groupId>
 		<artifactId>spring-boot</artifactId>
-		<version>3.14.2.redhat-00012</version>
+		<version>3.14.2.redhat-00018</version>
 	</parent>
 
 	<groupId>org.apache.camel.springboot.example</groupId>
@@ -92,9 +92,9 @@
 	</modules>
 
 	<properties>
-		<camel-version>3.14.2.redhat-00015</camel-version>
+		<camel-version>3.14.2.redhat-00026</camel-version>
                 <camel-community-version>3.14.2</camel-community-version>
-		<camel-spring-boot-version>3.14.2.redhat-00012</camel-spring-boot-version>
+		<camel-spring-boot-version>3.14.2.redhat-00018</camel-spring-boot-version>
 		<skip.starting.camel.context>false</skip.starting.camel.context>
 		<javax.servlet.api.version>4.0.1</javax.servlet.api.version>
 		<fabric8-maven-plugin-version>4.4.1</fabric8-maven-plugin-version>
@@ -175,7 +175,7 @@
 			<plugin>
 				<groupId>org.apache.camel</groupId>
 				<artifactId>camel-report-maven-plugin</artifactId>
-				<version>${camel-version}</version>
+				<version>${camel-community-version}</version>
 				<configuration>
 					<failOnError>false</failOnError>
 					<includeTest>true</includeTest>


### PR DESCRIPTION
Use community version of camel-report-maven-plugin - it is not productized and it is not included in the MRRC zip.