### PR TITLE
Upgrade version of jackson for swagger in order to avoid dupes in marete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot</groupId>
 		<artifactId>spring-boot</artifactId>
-		<version>3.14.2.redhat-00018</version>
+		<version>3.14.2.redhat-00034</version>
 	</parent>
 
 	<groupId>org.apache.camel.springboot.example</groupId>
@@ -92,9 +92,9 @@
 	</modules>
 
 	<properties>
-		<camel-version>3.14.2.redhat-00049</camel-version>
+		<camel-version>3.14.2.redhat-00050</camel-version>
         <camel-community-version>3.14.2</camel-community-version>
-		<camel-spring-boot-version>3.14.2.redhat-00033</camel-spring-boot-version>
+		<camel-spring-boot-version>3.14.2.redhat-00034</camel-spring-boot-version>
 		<skip.starting.camel.context>false</skip.starting.camel.context>
 		<javax.servlet.api.version>4.0.1</javax.servlet.api.version>
 		<fabric8-maven-plugin-version>4.4.1</fabric8-maven-plugin-version>

--- a/rest-swagger/pom.xml
+++ b/rest-swagger/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <category>Rest</category>
         <spring.boot-version>${spring-boot-version}</spring.boot-version>
-        <jackson.swagger.version>2.9.10</jackson.swagger.version>
+        <jackson.swagger.version>2.12.4</jackson.swagger.version>
     </properties>
 
     <!-- Spring-Boot and Camel BOM -->


### PR DESCRIPTION
- upgrade version of jackson for swagger (marete dupes)
- upgrade camel / camel-spring-boot productized versions