### PR TITLE
Remove camel community version, inherit property from parent

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,9 +35,9 @@ Number of Examples: 54 (0 deprecated)
 
 | link:health-checks/readme.adoc[Health Checks] (health-checks) |  | 
 
-| link:twitter-salesforce/README.adoc[Twitter Salesforce] (twitter-salesforce) |  | Twitter mentions is created as contacts in Salesforce
-
 | link:spring-boot-jta-jpa/readme.adoc[Spring Boot Jta Jpa] (spring-boot-jta-jpa) |  | An example showing JTA with Spring Boot
+
+| link:twitter-salesforce/README.adoc[Twitter Salesforce] (twitter-salesforce) |  | Twitter mentions is created as contacts in Salesforce
 
 | link:undertow-spring-security/readme.adoc[Undertow Spring Security] (undertow-spring-security) | Advanced | Example on how to use the Camel Undertow component with spring security and Keycloak
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot</groupId>
 		<artifactId>spring-boot</artifactId>
-		<version>3.14.2.redhat-00034</version>
+		<version>3.14.2.redhat-00054</version>
 	</parent>
 
 	<groupId>org.apache.camel.springboot.example</groupId>
@@ -93,9 +93,7 @@
 	</modules>
 
 	<properties>
-		<camel-version>3.14.2.redhat-00050</camel-version>
-        <camel-community-version>3.14.2</camel-community-version>
-		<camel-spring-boot-version>3.14.2.redhat-00034</camel-spring-boot-version>
+		<camel-spring-boot-version>3.14.2.redhat-00054</camel-spring-boot-version>
 		<skip.starting.camel.context>false</skip.starting.camel.context>
 		<javax.servlet.api.version>4.0.1</javax.servlet.api.version>
 		<fabric8-maven-plugin-version>4.4.1</fabric8-maven-plugin-version>
@@ -159,7 +157,7 @@
 			<plugin>
 				<groupId>org.apache.camel</groupId>
 				<artifactId>camel-package-maven-plugin</artifactId>
-				<version>${camel-community-version}</version>
+				<version>${camel-community.version}</version>
 				<configuration>
 					<startingFolder></startingFolder>
 					<filter>spring-boot</filter>
@@ -178,7 +176,7 @@
 			<plugin>
 				<groupId>org.apache.camel</groupId>
 				<artifactId>camel-report-maven-plugin</artifactId>
-				<version>${camel-community-version}</version>
+				<version>${camel-community.version}</version>
 				<configuration>
 					<failOnError>false</failOnError>
 					<includeTest>true</includeTest>


### PR DESCRIPTION
I'd like to remove camel-version and camel-community-version from the examples - we can inherit these from the parent I think.   I don't think there's a need to specify them and risk PNC alignment changing them -

camel-version https://github.com/jboss-fuse/camel-spring-boot/blob/camel-spring-boot-3.14.2-branch/pom.xml#L114
camel-community.version https://github.com/jboss-fuse/camel-spring-boot/blob/camel-spring-boot-3.14.2-branch/pom.xml#L118