### PR TITLE
Changes MySql dependency due to SB upgrade

### DIFF
--- a/rest-jpa/pom.xml
+++ b/rest-jpa/pom.xml
@@ -111,8 +111,8 @@
 
         <!-- JDBC -->
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/spring-boot-jta-jpa/pom.xml
+++ b/spring-boot-jta-jpa/pom.xml
@@ -100,8 +100,8 @@
             <artifactId>camel-jpa-starter</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>

--- a/spring-boot-jta-jpa/readme.adoc
+++ b/spring-boot-jta-jpa/readme.adoc
@@ -59,7 +59,7 @@ curl $ADDRESS/messages
 Test rollback by calling the service with "fail" content:
 
 ----
-curl -X POST $ADDRESS/message/fail
+curl -X POST $ADDRESS/messages/fail
 ----
 
 You should not find any trace of the message in the `audit_log` table.


### PR DESCRIPTION
since SB 2.7.8 the dependency `mysql-connector-java` has been removed in the SB BOM