### PR TITLE
Use redhat version of the camel-spring-boot-bom - spring-jdbc is not …

### DIFF
--- a/spring-jdbc/pom.xml
+++ b/spring-jdbc/pom.xml
@@ -49,9 +49,9 @@
 			</dependency>
 			<!-- Camel BOM -->
 			<dependency>
-				<groupId>org.apache.camel.springboot</groupId>
+				<groupId>com.redhat.camel.springboot.platform</groupId>
 				<artifactId>camel-spring-boot-bom</artifactId>
-				<version>${project.version}</version>
+				<version>${camel-spring-boot-version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
Use redhat version of the camel-spring-boot-bom - spring-jdbc is not using productized versions of artifacts