### PR TITLE
Add a profile that weeds out tests that require docker

### DIFF
--- a/Jenkinsfile.redhat
+++ b/Jenkinsfile.redhat
@@ -55,7 +55,7 @@ pipeline {
             steps {
                 configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                     script {
-                        spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dmaven.test.failure.ignore=true clean install", returnStatus: true
+                        spring_boot_itests_result = sh script: "./mvnw -Pdocker-skip-tests $MAVEN_PARAMS -Dmaven.test.failure.ignore=true clean install", returnStatus: true
                     }
                 }
             }

--- a/fhir/pom.xml
+++ b/fhir/pom.xml
@@ -159,4 +159,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>docker-skip-tests</id>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -116,4 +116,12 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>docker-skip-tests</id>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
The Fuse Jenkins machine is throwing up too many requests on docker pulls, I think because the Red Hat subnet has been banned.    I'd like to add a profile that skips docker-required tests so that we can still run the test suite on Jenkins.