### PR TITLE
Use the version of guava from camel so we don't run into MRRC errors

### DIFF
--- a/jira/pom.xml
+++ b/jira/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>26.0-jre</version>
+            <version>${guava-version}</version>
         </dependency>
 
         <!-- Spring Boot -->


### PR DESCRIPTION
This is for camel 4 - use the version of guava from camel so we don't run into MRRC errors on a guava version not contained in the MRRC.