### PR TITLE
Adds http-ssl example (#130)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -127,7 +127,8 @@ Number of Examples: 46 (0 deprecated)
 | link:widget-gadget/README.adoc[Widget Gadget] (widget-gadget) | Messaging | The widget and gadget example from EIP book, running on Spring Boot
 
 | link:reactive-streams/readme.adoc[Reactive Streams] (reactive-streams) | Reactive | An example that shows how Camel can exchange data using reactive streams with Spring Boot reactor
-    
+
+| link:http-ssl/README.adoc[Http Ssl] (http-ssl) | Rest | An example showing the Camel HTTP component with Spring Boot and SSL
 
 | link:rest-openapi/README.adoc[Rest Openapi] (rest-openapi) | Rest | An example showing Camel REST DSL and OpenApi with Spring Boot
 

--- a/http-ssl/.gitignore
+++ b/http-ssl/.gitignore
@@ -1,0 +1,3 @@
+ssl
+*.jks
+*.pem

--- a/http-ssl/README.adoc
+++ b/http-ssl/README.adoc
@@ -1,0 +1,66 @@
+== Spring Boot Example with HTTP and SSL
+
+=== Introduction
+
+This example shows how to configure SSL in different scenarios:
+
+1. one way SSL, the server exposes REST API using SSL and the client trusts the server certificate. The SSL server configuration is managed by Spring Boot and the Camel inherit it, the SSL client configuration is managed by Camel in HTTP component
+2. two ways SSL, the server and the client check both certificates in a mutual trusted handshake
+3. same scenario as point 1 but the server configuration is managed directly in Camel (undertow component) instead of Spring Boot
+
+=== Prerequisites
+
+keytool installed and available on PATH
+
+Generate certificates and keystores
+
+    $ ./generate-certificates.sh
+
+=== Run using one way ssl (server validation on client side)
+
+Start ssl-server in a separate terminal:
+
+    $ mvn spring-boot:run -f ssl-server/pom.xml
+
+Start ssl-client in a separate terminal:
+
+    $ mvn spring-boot:run -f ssl-client/pom.xml
+
+=== Run using two ways ssl (mutual validation)
+
+Start ssl-server in a separate terminal:
+
+    $ mvn spring-boot:run -f ssl-server/pom.xml -Ptwoways
+
+Start ssl-client in a separate terminal:
+
+    $ mvn spring-boot:run -f ssl-client/pom.xml -Ptwoways
+
+=== Run using Camel component as server
+
+Start ssl-camel-server in a separate terminal:
+
+    $ mvn spring-boot:run -f ssl-camel-server/pom.xml
+
+Start ssl-client in a separate terminal:
+
+    $ mvn spring-boot:run -f ssl-client/pom.xml
+
+=== Call service to start handshake
+
+    $ curl http://localhost:8080/ping
+
+==== Tip
+
+to show the full handshake it is possible to add `-Dspring-boot.run.jvmArguments="-Djavax.net.debug=all"` in the start command line
+
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/community/support/[let us know].
+
+We also love contributors, so
+https://camel.apache.org/community/contributing/[get involved] :-)
+
+The Camel riders!

--- a/http-ssl/generate-certificates.sh
+++ b/http-ssl/generate-certificates.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+GEN_DIR="ssl"
+
+K_PASS=pass123
+SERVER_JKS=$GEN_DIR/server.jks
+SERVER_CERT=$GEN_DIR/server.pem
+SERVER_TRUST=$GEN_DIR/server-truststore.jks
+CLIENT_JKS=$GEN_DIR/client.jks
+CLIENT_CERT=$GEN_DIR/client.pem
+CLIENT_TRUST=$GEN_DIR/client-truststore.jks
+
+echo remove directory $GEN_DIR if exists
+[ -e $GEN_DIR ] && rm -rf $GEN_DIR
+
+echo create directory $GEN_DIR
+mkdir -p $GEN_DIR
+
+echo generate server certificates
+keytool -alias server -dname "cn=localhost, ou=ssl-server, o=csb-http-ssl, c=US" -genkeypair -storepass $K_PASS -keyalg RSA -keystore $SERVER_JKS
+
+echo generate client certificates
+keytool -alias client -dname "cn=localhost, ou=ssl-client, o=csb-http-ssl, c=US" -genkeypair -storepass $K_PASS -keyalg RSA -keystore $CLIENT_JKS
+
+echo export server certificates
+keytool -exportcert -alias server -storepass $K_PASS -keystore $SERVER_JKS -rfc -file $SERVER_CERT
+
+echo export client certificates
+keytool -exportcert -alias client -storepass $K_PASS -keystore $CLIENT_JKS -rfc -file $CLIENT_CERT
+
+echo import server in client truststore
+keytool -import -keystore $CLIENT_TRUST -storepass $K_PASS -file $SERVER_CERT -alias server -noprompt -trustcacerts
+
+echo import client in server truststore
+keytool -import -keystore $SERVER_TRUST -storepass $K_PASS -file $CLIENT_CERT -alias client -noprompt -trustcacerts
+
+echo copy $SERVER_JKS in ssl-server/src/main/resources
+[ -e ssl-server/src/main/resources/server.jks ] && rm ssl-server/src/main/resources/server.jks
+cp $SERVER_JKS ssl-server/src/main/resources/server.jks
+
+echo copy $SERVER_TRUST in ssl-server/src/main/resources
+[ -e ssl-server/src/main/resources/server-truststore.jks ] && rm ssl-server/src/main/resources/server-truststore.jks
+cp $SERVER_TRUST ssl-server/src/main/resources/server-truststore.jks
+
+echo copy $CLIENT_JKS in ssl-client/src/main/resources
+[ -e ssl-client/src/main/resources/client.jks ] && rm ssl-client/src/main/resources/client.jks
+cp $CLIENT_JKS ssl-client/src/main/resources/client.jks
+
+echo copy $CLIENT_TRUST in ssl-client/src/main/resources
+[ -e ssl-client/src/main/resources/client-truststore.jks ] && rm ssl-client/src/main/resources/client-truststore.jks
+cp $CLIENT_TRUST ssl-client/src/main/resources/client-truststore.jks
+
+echo copy $SERVER_JKS in ssl-camel-server/src/main/resources
+[ -e ssl-camel-server/src/main/resources/server.jks ] && rm ssl-camel-server/src/main/resources/server.jks
+cp $SERVER_JKS ssl-camel-server/src/main/resources/server.jks

--- a/http-ssl/pom.xml
+++ b/http-ssl/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.camel.springboot.example</groupId>
+		<artifactId>examples</artifactId>
+		<version>4.4.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>camel-example-spring-boot-http-ssl</artifactId>
+	<name>Camel SB Examples :: HTTP SSL</name>
+	<description>An example showing the Camel HTTP component with Spring Boot and SSL</description>
+	<packaging>pom</packaging>
+
+	<properties>
+		<category>Rest</category>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.redhat.camel.springboot.platform</groupId>
+				<artifactId>camel-spring-boot-bom</artifactId>
+				<version>${camel-spring-boot-version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<modules>
+		<module>ssl-server</module>
+		<module>ssl-client</module>
+		<module>ssl-camel-server</module>
+	</modules>
+
+</project>

--- a/http-ssl/ssl-camel-server/pom.xml
+++ b/http-ssl/ssl-camel-server/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.camel.springboot.example</groupId>
+		<artifactId>camel-example-spring-boot-http-ssl</artifactId>
+		<version>4.4.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>camel-example-spring-boot-http-ssl-camel-server</artifactId>
+	<name>Camel SB Examples :: HTTP SSL :: SSL Camel server</name>
+	<description>SSL Server using undertow component</description>
+
+	<properties>
+		<category>Rest</category>
+
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
+	<dependencies>
+
+		<!-- Camel -->
+		<dependency>
+			<groupId>org.apache.camel.springboot</groupId>
+			<artifactId>camel-spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel.springboot</groupId>
+			<artifactId>camel-undertow-starter</artifactId>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${spring-boot-version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/http-ssl/ssl-camel-server/src/main/java/org/apache/camel/springboot/example/httpssl/HttpSslCamelServerApplication.java
+++ b/http-ssl/ssl-camel-server/src/main/java/org/apache/camel/springboot/example/httpssl/HttpSslCamelServerApplication.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.springboot.example.httpssl;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class HttpSslCamelServerApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(HttpSslCamelServerApplication.class, args);
+	}
+}

--- a/http-ssl/ssl-camel-server/src/main/java/org/apache/camel/springboot/example/httpssl/HttpSslCamelServerRouter.java
+++ b/http-ssl/ssl-camel-server/src/main/java/org/apache/camel/springboot/example/httpssl/HttpSslCamelServerRouter.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.springboot.example.httpssl;
+
+import org.apache.camel.builder.RouteBuilder;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class HttpSslCamelServerRouter extends RouteBuilder {
+	@Override
+	public void configure() throws Exception {
+		from("undertow:{{exposed.server.url}}/ping")
+				.setBody().constant("pong");
+	}
+}

--- a/http-ssl/ssl-camel-server/src/main/java/org/apache/camel/springboot/example/httpssl/SSLConfiguration.java
+++ b/http-ssl/ssl-camel-server/src/main/java/org/apache/camel/springboot/example/httpssl/SSLConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.springboot.example.httpssl;
+
+import org.apache.camel.support.jsse.KeyManagersParameters;
+import org.apache.camel.support.jsse.KeyStoreParameters;
+import org.apache.camel.support.jsse.SSLContextParameters;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SSLConfiguration {
+
+	@Bean("serverConfig")
+	public SSLContextParameters sslContextParameters(@Value("${keystore-password}") final String password
+			, @Value("${keystore-resource}") final String keystore) {
+		final SSLContextParameters sslContextParameters = new SSLContextParameters();
+
+		final KeyStoreParameters ksp = new KeyStoreParameters();
+		ksp.setResource(keystore);
+		ksp.setPassword(password);
+		ksp.setType("PKCS12");
+
+		KeyManagersParameters kmp = new KeyManagersParameters();
+		kmp.setKeyPassword(password);
+		kmp.setKeyStore(ksp);
+
+		sslContextParameters.setKeyManagers(kmp);
+
+		return sslContextParameters;
+	}
+}

--- a/http-ssl/ssl-camel-server/src/main/resources/application.properties
+++ b/http-ssl/ssl-camel-server/src/main/resources/application.properties
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+camel.springboot.name=ssl-camel-server
+camel.component.undertow.ssl-context-parameters=#serverConfig
+camel.component.undertow.use-global-ssl-context-parameters=true
+keystore-password=pass123
+keystore-resource=classpath:server.jks
+exposed.server.url=https://localhost:8443
+logging.level.org.apache.camel.support.jsse=TRACE

--- a/http-ssl/ssl-client/pom.xml
+++ b/http-ssl/ssl-client/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.camel.springboot.example</groupId>
+		<artifactId>camel-example-spring-boot-http-ssl</artifactId>
+		<version>4.4.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>camel-example-spring-boot-http-ssl-client</artifactId>
+	<name>Camel SB Examples :: HTTP SSL :: SSL client</name>
+	<description>SSL Client using http component</description>
+
+	<properties>
+		<category>Rest</category>
+
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
+	<dependencies>
+
+		<!-- Spring Boot -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-tomcat</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-undertow</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<!-- Camel -->
+		<dependency>
+			<groupId>org.apache.camel.springboot</groupId>
+			<artifactId>camel-spring-boot-starter</artifactId>
+		</dependency>
+		<!-- to expose rest services -->
+		<dependency>
+			<groupId>org.apache.camel.springboot</groupId>
+			<artifactId>camel-platform-http-starter</artifactId>
+		</dependency>
+		<!-- component used as client -->
+		<dependency>
+			<groupId>org.apache.camel.springboot</groupId>
+			<artifactId>camel-http-starter</artifactId>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<excludes>
+					<exclude>**/*.jks</exclude>
+				</excludes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>false</filtering>
+				<includes>
+					<include>**/*.jks</include>
+				</includes>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${spring-boot-version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<profiles>
+		<profile>
+			<id>oneway</id>
+			<properties>
+				<sbProfile>oneway</sbProfile>
+			</properties>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+		</profile>
+		<profile>
+			<id>twoways</id>
+			<properties>
+				<sbProfile>twoways</sbProfile>
+			</properties>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+		</profile>
+	</profiles>
+</project>

--- a/http-ssl/ssl-client/src/main/java/org/apache/camel/springboot/example/httpssl/HttpSslClientApplication.java
+++ b/http-ssl/ssl-client/src/main/java/org/apache/camel/springboot/example/httpssl/HttpSslClientApplication.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.springboot.example.httpssl;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class HttpSslClientApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(HttpSslClientApplication.class, args);
+	}
+}

--- a/http-ssl/ssl-client/src/main/java/org/apache/camel/springboot/example/httpssl/HttpSslClientRouter.java
+++ b/http-ssl/ssl-client/src/main/java/org/apache/camel/springboot/example/httpssl/HttpSslClientRouter.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.springboot.example.httpssl;
+
+import org.apache.camel.builder.RouteBuilder;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HttpSslClientRouter extends RouteBuilder {
+	@Override
+	public void configure() throws Exception {
+		rest()
+				.get("ping")
+				.produces(MediaType.TEXT_PLAIN_VALUE)
+				.to("direct:call-ssl-server");
+
+		from("direct:call-ssl-server")
+				.to("{{ssl-server.url}}/ping?bridgeEndpoint=true");
+	}
+}

--- a/http-ssl/ssl-client/src/main/java/org/apache/camel/springboot/example/httpssl/SSLConfiguration.java
+++ b/http-ssl/ssl-client/src/main/java/org/apache/camel/springboot/example/httpssl/SSLConfiguration.java
@@ -1,0 +1,67 @@
+package org.apache.camel.springboot.example.httpssl;
+
+import org.apache.camel.support.jsse.FilterParameters;
+import org.apache.camel.support.jsse.KeyManagersParameters;
+import org.apache.camel.support.jsse.KeyStoreParameters;
+import org.apache.camel.support.jsse.SSLContextClientParameters;
+import org.apache.camel.support.jsse.SSLContextParameters;
+import org.apache.camel.support.jsse.TrustManagersParameters;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+public class SSLConfiguration {
+
+	@Bean("clientConfigOneWay")
+	@Profile("oneway")
+	public SSLContextParameters sslContextParameters(@Value("${keystore-password}") final String password
+			, @Value("${truststore-resource}") final String truststore) {
+		return getTrustedSSLContextParameters(password, truststore);
+	}
+
+	@Bean("clientConfigTwoWays")
+	@Profile("twoways")
+	public SSLContextParameters sslContextParametersTwoWays(@Value("${keystore-password}") final String password
+			, @Value("${truststore-resource}") final String truststore
+			, @Value("${keystore-resource}") final String keystore) {
+		final SSLContextParameters sslContextParameters = getTrustedSSLContextParameters(password, truststore);
+
+		final KeyStoreParameters ksp = new KeyStoreParameters();
+		ksp.setResource(keystore);
+		ksp.setPassword(password);
+
+		final KeyManagersParameters kmp = new KeyManagersParameters();
+		kmp.setKeyStore(ksp);
+		kmp.setKeyPassword(password);
+
+		sslContextParameters.setKeyManagers(kmp);
+		sslContextParameters.setCertAlias("client");
+
+		return sslContextParameters;
+	}
+
+	private SSLContextParameters getTrustedSSLContextParameters(final String password, final String truststore) {
+		final SSLContextParameters sslContextParameters = new SSLContextParameters();
+
+		final KeyStoreParameters ksp = new KeyStoreParameters();
+		ksp.setResource(truststore);
+		ksp.setPassword(password);
+
+		final FilterParameters filter = new FilterParameters();
+		filter.getInclude().add(".*");
+
+		final SSLContextClientParameters sccp = new SSLContextClientParameters();
+		sccp.setCipherSuitesFilter(filter);
+
+		final TrustManagersParameters tmp = new TrustManagersParameters();
+		tmp.setKeyStore(ksp);
+
+		sslContextParameters.setTrustManagers(tmp);
+		sslContextParameters.setClientParameters(sccp);
+
+		return sslContextParameters;
+	}
+}

--- a/http-ssl/ssl-client/src/main/resources/application-oneway.properties
+++ b/http-ssl/ssl-client/src/main/resources/application-oneway.properties
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+camel.component.http.ssl-context-parameters=#clientConfigOneWay

--- a/http-ssl/ssl-client/src/main/resources/application-twoways.properties
+++ b/http-ssl/ssl-client/src/main/resources/application-twoways.properties
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+camel.component.http.ssl-context-parameters=#clientConfigTwoWays

--- a/http-ssl/ssl-client/src/main/resources/application.properties
+++ b/http-ssl/ssl-client/src/main/resources/application.properties
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spring.profiles.active = ${sbProfile}
+camel.springboot.name=ssl-client
+camel.component.http.use-global-ssl-context-parameters=true
+management.endpoint.camelroutes.enabled=true
+management.endpoint.camelroutes.read-only=true
+management.endpoint.health.enabled=true
+management.endpoints.web.exposure.include=info,health,camelroutes
+keystore-password=pass123
+keystore-resource=classpath:client.jks
+truststore-resource=classpath:client-truststore.jks
+ssl-server.url=https://localhost:8443
+logging.level.org.apache.camel.support.jsse=TRACE

--- a/http-ssl/ssl-server/pom.xml
+++ b/http-ssl/ssl-server/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.camel.springboot.example</groupId>
+		<artifactId>camel-example-spring-boot-http-ssl</artifactId>
+		<version>4.4.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>camel-example-spring-boot-http-ssl-server</artifactId>
+	<name>Camel SB Examples :: HTTP SSL :: SSL server</name>
+	<description>SSL Server using platform-http</description>
+
+	<properties>
+		<category>Rest</category>
+
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
+	<dependencies>
+
+		<!-- Spring Boot -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-tomcat</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-undertow</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<!-- Camel -->
+		<dependency>
+			<groupId>org.apache.camel.springboot</groupId>
+			<artifactId>camel-spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel.springboot</groupId>
+			<artifactId>camel-platform-http-starter</artifactId>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<excludes>
+					<exclude>**/*.jks</exclude>
+				</excludes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>false</filtering>
+				<includes>
+					<include>**/*.jks</include>
+				</includes>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${spring-boot-version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<profiles>
+		<profile>
+			<id>oneway</id>
+			<properties>
+				<sbProfile>oneway</sbProfile>
+			</properties>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+		</profile>
+		<profile>
+			<id>twoways</id>
+			<properties>
+				<sbProfile>twoways</sbProfile>
+			</properties>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+		</profile>
+	</profiles>
+</project>

--- a/http-ssl/ssl-server/src/main/java/org/apache/camel/springboot/example/httpssl/HttpSslServerApplication.java
+++ b/http-ssl/ssl-server/src/main/java/org/apache/camel/springboot/example/httpssl/HttpSslServerApplication.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.springboot.example.httpssl;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class HttpSslServerApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(HttpSslServerApplication.class, args);
+	}
+}

--- a/http-ssl/ssl-server/src/main/java/org/apache/camel/springboot/example/httpssl/HttpSslServerRouter.java
+++ b/http-ssl/ssl-server/src/main/java/org/apache/camel/springboot/example/httpssl/HttpSslServerRouter.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.springboot.example.httpssl;
+
+import org.apache.camel.builder.RouteBuilder;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HttpSslServerRouter extends RouteBuilder {
+	@Override
+	public void configure() throws Exception {
+		rest()
+				.get("ping")
+				.produces(MediaType.TEXT_PLAIN_VALUE)
+				.to("direct:pong");
+
+		from("direct:pong")
+				.setBody().constant("pong");
+	}
+}

--- a/http-ssl/ssl-server/src/main/resources/application-oneway.properties
+++ b/http-ssl/ssl-server/src/main/resources/application-oneway.properties
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server.ssl.client-auth=NONE

--- a/http-ssl/ssl-server/src/main/resources/application-twoways.properties
+++ b/http-ssl/ssl-server/src/main/resources/application-twoways.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server.ssl.client-auth=NEED
+spring.ssl.bundle.jks.server.truststore.location=classpath:server-truststore.jks
+spring.ssl.bundle.jks.server.truststore.password=pass123
+spring.ssl.bundle.jks.server.truststore.type=PKCS12

--- a/http-ssl/ssl-server/src/main/resources/application.properties
+++ b/http-ssl/ssl-server/src/main/resources/application.properties
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spring.profiles.active = ${sbProfile}
+camel.springboot.name=ssl-server
+management.endpoint.camelroutes.enabled=true
+management.endpoint.camelroutes.read-only=true
+management.endpoint.health.enabled=true
+management.endpoints.web.exposure.include=info,health,camelroutes
+server.port=8443
+server.ssl.bundle=server
+spring.ssl.bundle.jks.server.key.alias=server
+spring.ssl.bundle.jks.server.keystore.location=classpath:server.jks
+spring.ssl.bundle.jks.server.keystore.password=pass123
+spring.ssl.bundle.jks.server.keystore.type=PKCS12

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
 		<module>fhir</module>
 		<module>fhir-auth-tx</module>
 		<module>health-checks</module>
+		<module>http-ssl</module>
 		<module>infinispan</module>
 		<module>jira</module>
 		<module>kafka-avro</module>


### PR DESCRIPTION
cherry pick https://github.com/apache/camel-spring-boot-examples/commit/19af663dc7ad6eee4d72229ee460bef88c9712c7 and adapted to product BOM, undertow instead of tomcat and parametrized hard coded values