### PR TITLE
Add Examples from Upstream

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ readme's instructions.
 === Examples
 
 // examples: START
-Number of Examples: 52 (0 deprecated)
+Number of Examples: 54 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===
@@ -122,6 +122,10 @@ Number of Examples: 52 (0 deprecated)
 | link:amqp/readme.adoc[Amqp] (amqp) | Messaging | An example showing how to work with Camel, ActiveMQ Amqp and Spring Boot
 
 | link:artemis/readme.adoc[Artemis] (artemis) | Messaging | An example showing how to work with Camel, ActiveMQ Artemis and Spring Boot
+
+| link:azure/camel-example-spring-boot-azure-eventhubs/README.adoc[Spring Boot Azure Eventhubs] (camel-example-spring-boot-azure-eventhubs) | Cloud | An example showing how to work with Camel, Azure Event Hubs and Spring Boot
+
+| link:azure/camel-example-spring-boot-azure-servicebus/README.adoc[Spring Boot Azure Servicebus] (camel-example-spring-boot-azure-servicebus) | Cloud | An example showing how to work with Camel, Azure Service Bus and Spring Boot
 
 | link:kafka-avro/README.adoc[Kafka Avro] (kafka-avro) | Messaging | An example for Kafka avro
 

--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ readme's instructions.
 === Examples
 
 // examples: START
-Number of Examples: 51 (0 deprecated)
+Number of Examples: 52 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===
@@ -81,13 +81,13 @@ Number of Examples: 51 (0 deprecated)
 
 | link:master/readme.adoc[Master] (master) | Clustering | An example showing how to work with Camel's Master component and Spring Boot
 
+| link:rest-cxf-opentelemetry/README.adoc[Rest Cxf Opentelemetry] (rest-cxf-opentelemetry) | CXF | An example showing Camel REST using CXF and OpenTelemetry with Spring Boot
+
 | link:soap-cxf/README.adoc[Soap Cxf] (soap-cxf) | CXF | An example showing the Camel SOAP CXF
 
 | link:arangodb/README.adoc[Arangodb] (arangodb) | Database | An example showing the Camel ArangoDb component with Spring Boot
 
 | link:resilience4j/README.adoc[Resilience4j] (resilience4j) | EIP | An example showing how to use Resilience4j EIP as circuit breaker in Camel routes
-
-| link:rest-cxf-opentelemetry/README.adoc[Rest Cxf Opentelemetry] (rest-cxf-opentelemetry) | CXF | An example showing Camel REST using CXF and OpenTelemetry with Spring Boot
 
 | link:saga/readme.adoc[Saga] (saga) | EIP | This example shows how to work with a simple Apache Camel application using Spring Boot and Narayana LRA Coordinator to manage distributed actions implementing SAGA pattern
 
@@ -120,6 +120,8 @@ Number of Examples: 51 (0 deprecated)
 | link:activemq/readme.adoc[Activemq] (activemq) | Messaging | An example showing how to work with Camel, ActiveMQ openwire and Spring Boot
 
 | link:amqp/readme.adoc[Amqp] (amqp) | Messaging | An example showing how to work with Camel, ActiveMQ Amqp and Spring Boot
+
+| link:artemis/readme.adoc[Artemis] (artemis) | Messaging | An example showing how to work with Camel, ActiveMQ Artemis and Spring Boot
 
 | link:kafka-avro/README.adoc[Kafka Avro] (kafka-avro) | Messaging | An example for Kafka avro
 

--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ readme's instructions.
 === Examples
 
 // examples: START
-Number of Examples: 55 (0 deprecated)
+Number of Examples: 56 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===
@@ -151,6 +151,8 @@ Number of Examples: 55 (0 deprecated)
 | link:rest-openapi/README.adoc[Rest Openapi] (rest-openapi) | Rest | An example showing Camel REST DSL and OpenApi with Spring Boot
 
 | link:rest-openapi-springdoc/README.adoc[Rest Openapi Springdoc] (rest-openapi-springdoc) | Rest | An example showing Camel REST DSL and OpenApi with a Springdoc UI in a Spring Boot application
+
+| link:openapi-contract-first/readme.adoc[Openapi Contract First] (openapi-contract-first) | Rest | Contract First OpenAPI example
 |===
 // examples: END
 

--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ readme's instructions.
 === Examples
 
 // examples: START
-Number of Examples: 56 (0 deprecated)
+Number of Examples: 57 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===
@@ -153,6 +153,8 @@ Number of Examples: 56 (0 deprecated)
 | link:rest-openapi-springdoc/README.adoc[Rest Openapi Springdoc] (rest-openapi-springdoc) | Rest | An example showing Camel REST DSL and OpenApi with a Springdoc UI in a Spring Boot application
 
 | link:openapi-contract-first/readme.adoc[Openapi Contract First] (openapi-contract-first) | Rest | Contract First OpenAPI example
+
+| link:platform-http/README.adoc[Platform Http] (platform-http) | Rest | An example showing Camel REST DSL with platform HTTP
 |===
 // examples: END
 

--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ readme's instructions.
 === Examples
 
 // examples: START
-Number of Examples: 58 (0 deprecated)
+Number of Examples: 59 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===
@@ -62,6 +62,8 @@ Number of Examples: 58 (0 deprecated)
 | link:routes-configuration/readme.adoc[Routes Configuration] (routes-configuration) | Beginner | Example with global routes configuration for error handling
 
 | link:routetemplate/readme.adoc[Routetemplate] (routetemplate) | Beginner | How to use route templates (parameterized routes)
+
+| link:routetemplate-xml/README.adoc[Routetemplate Xml] (routetemplate-xml) | Beginner | How to use route templates (parameterized routes) in XML
 
 | link:splitter-eip/README.adoc[Splitter Eip] (splitter-eip) | Beginner | An example showing Splitter EIP with Camel and Spring Boot
 

--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ readme's instructions.
 === Examples
 
 // examples: START
-Number of Examples: 54 (0 deprecated)
+Number of Examples: 55 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===
@@ -36,6 +36,8 @@ Number of Examples: 54 (0 deprecated)
 | link:amqp-salesforce/README.adoc[Amqp Salesforce] (amqp-salesforce) |  | AMQP message sending is created as contacts in Salesforce
 
 | link:health-checks/readme.adoc[Health Checks] (health-checks) |  | 
+
+| link:endpointdsl/readme.adoc[Endpointdsl] (endpointdsl) | Beginner | Using type-safe Endpoint DSL
 
 | link:spring-boot-jta-jpa-autoconfigure/readme.adoc[Spring Boot Jta Jpa Autoconfigure] (spring-boot-jta-jpa-autoconfigure) | Advanced | An example showing JTA with Spring Boot Autoconfiguration
 

--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ readme's instructions.
 === Examples
 
 // examples: START
-Number of Examples: 57 (0 deprecated)
+Number of Examples: 58 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===
@@ -58,6 +58,8 @@ Number of Examples: 57 (0 deprecated)
 | link:rest-openapi-simple/README.adoc[REST OpenApi] (rest-openapi-simple) | Beginner | This example shows how to call a Rest service defined using OpenApi specification
 
 | link:route-reload/readme.adoc[Spring Boot Route Reload] (route-reload) | Beginner | Live reload of routes if file is updated and saved
+
+| link:routes-configuration/readme.adoc[Routes Configuration] (routes-configuration) | Beginner | Example with global routes configuration for error handling
 
 | link:routetemplate/readme.adoc[Routetemplate] (routetemplate) | Beginner | How to use route templates (parameterized routes)
 

--- a/artemis/pom.xml
+++ b/artemis/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Licensed to the Apache Software Foundation (ASF) under one or more
@@ -16,8 +17,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -26,16 +27,17 @@
         <version>4.8.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>camel-example-spring-boot-rest-openapi</artifactId>
-    <name>Camel SB Examples :: REST DSL and OpenApi</name>
-    <description>An example showing Camel REST DSL and OpenApi with Spring Boot</description>
+    <artifactId>camel-example-spring-boot-artemis</artifactId>
+    <name>Camel SB Examples :: artemis</name>
+    <description>An example showing how to work with Camel, ActiveMQ Artemis and Spring Boot</description>
 
     <properties>
-        <category>Rest</category>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <category>Messaging</category>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
-    <!-- Spring-Boot and Camel BOM -->
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -49,20 +51,14 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- Spring Boot -->
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-tomcat</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-undertow</artifactId>
+            <artifactId>spring-boot-starter-artemis</artifactId>
         </dependency>
 
         <!-- Camel -->
@@ -70,37 +66,33 @@
             <groupId>org.apache.camel.springboot</groupId>
             <artifactId>camel-spring-boot-starter</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-openapi-java-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-servlet-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-jackson-starter</artifactId>
-        </dependency>
 
-        <!-- metrics and expose for prometheus -->
+        <!-- Add the Artemis jakarta client library which will include the ActiveMQConnectionFactory -->
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jakarta-client</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jakarta-server</artifactId>
+        </dependency> 
+               
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-jms-starter</artifactId>
+        </dependency>
+       
+        <!-- test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-micrometer-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
-        </dependency>
-
-        <!-- Test -->
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-management-starter</artifactId>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-spring-junit5</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -109,7 +101,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot-version}</version>
+                <version>${spring-boot-version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -120,5 +112,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/artemis/readme.adoc
+++ b/artemis/readme.adoc
@@ -1,0 +1,24 @@
+== Camel Example Spring Boot and ActiveMQ Artemis
+
+This example shows how to work with a simple Apache Camel application using Spring Boot and Apache ActiveMQ Artemis.
+
+=== How to run the example
+
+You can run this example using
+
+    mvn spring-boot:run
+
+=== Using Camel components
+
+Apache Camel provides 200+ components which you can use to integrate and route messages between many systems
+and data formats. To use any of these Camel components, add the component as a dependency to your project.
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/support.html[let us know].
+
+We also love contributors, so
+https://camel.apache.org/contributing.html[get involved] :-)
+
+The Camel riders!

--- a/artemis/src/main/data/readme.adoc
+++ b/artemis/src/main/data/readme.adoc
@@ -1,0 +1,4 @@
+
+== Camel Example Spring Boot and ActiveMQ Artemis ==
+The APACHE Camel riders!
+

--- a/artemis/src/main/java/sample/camel/SampleAmqApplication.java
+++ b/artemis/src/main/java/sample/camel/SampleAmqApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+//CHECKSTYLE:OFF
+@SpringBootApplication
+public class SampleAmqApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SampleAmqApplication.class, args);
+    }
+}
+// CHECKSTYLE:ON

--- a/artemis/src/main/java/sample/camel/SampleJmsRoute.java
+++ b/artemis/src/main/java/sample/camel/SampleJmsRoute.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SampleJmsRoute extends RouteBuilder {
+       
+    @Override
+    public void configure() throws Exception {
+
+        from("file:src/main/data?noop=true")
+            .to("jms:queue:{{spring.artemis.embedded.queue}}");
+
+       
+        from("jms:queue:{{spring.artemis.embedded.queue}}")
+            .log("${body}");
+    }
+}

--- a/artemis/src/main/resources/application.properties
+++ b/artemis/src/main/resources/application.properties
@@ -1,0 +1,27 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+#You can use this property to override the default autowired broker-url
+camel.springboot.main-run-controller = true
+#spring.artemis.mode=native
+spring.artemis.mode=embedded
+spring.artemis.host=localhost
+spring.artemis.port=61616
+spring.artemis.user=test
+spring.artemis.password=test
+spring.artemis.embedded.enabled=true
+spring.artemis.embedded.queue=SCIENCEQUEUE

--- a/artemis/src/test/java/sample/camel/SampleAmqApplicationTests.java
+++ b/artemis/src/test/java/sample/camel/SampleAmqApplicationTests.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@CamelSpringBootTest
+@SpringBootTest(classes = SampleAmqApplication.class)
+public class SampleAmqApplicationTests {
+    @Autowired
+    private CamelContext camelContext;
+
+    @Test
+    public void shouldProduceMessages() throws Exception {
+        NotifyBuilder notify = new NotifyBuilder(camelContext).whenDone(1).create();
+        assertTrue(notify.matches(10, TimeUnit.SECONDS));
+    }
+}

--- a/azure/camel-example-spring-boot-azure-eventhubs/README.adoc
+++ b/azure/camel-example-spring-boot-azure-eventhubs/README.adoc
@@ -1,0 +1,50 @@
+== Spring Boot Example with Azure Event Hubs
+
+=== Introduction
+
+This example demonstrates how you can use the Camel Azure Event Hubs Starter component.
+
+NOTE: Running this sample will be charged by Azure. You can check the usage and bill at this https://azure.microsoft.com/get-started/azure-portal/[link].
+
+=== Create Event Hubs on Azure
+
+1. Create an Azure Event Hubs by following this https://learn.microsoft.com/azure/event-hubs/event-hubs-create[link].
+
+2. Create an Azure Storage account for checkpoint use by following this https://learn.microsoft.com/azure/storage/common/storage-account-create?tabs=azure-portal[link].
+
+=== Configuration
+
+You need to configure the details in the file:
+
+`src/main/resources/application.yml`
+
+=== How to run
+
+Run this example using:
+
+[source,console]
+----
+mvn spring-boot:run
+----
+
+You should see the following output in the console.
+
+[source,console]
+----
+Received: Event Test
+The content is Event Test
+...
+Received: Event Test
+The content is Event Test
+...
+----
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/community/support/[let us know].
+
+We also love contributors, so
+https://camel.apache.org/community/contributing/[get involved] :-)
+
+The Camel riders!

--- a/azure/camel-example-spring-boot-azure-eventhubs/pom.xml
+++ b/azure/camel-example-spring-boot-azure-eventhubs/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <artifactId>camel-example-spring-boot-azure</artifactId>
+    <version>4.8.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>camel-example-spring-boot-azure-eventhubs</artifactId>
+  <name>Camel SB Examples :: Azure Event Hubs</name>
+  <description>An example showing how to work with Camel, Azure Event Hubs and Spring Boot</description>
+
+  <properties>
+    <category>Cloud</category>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+
+    <!-- Camel -->
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-azure-eventhubs-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-endpointdsl-starter</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot-version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/azure/camel-example-spring-boot-azure-eventhubs/src/main/java/camel/sample/EventhubsRouteBuilder.java
+++ b/azure/camel-example-spring-boot-azure-eventhubs/src/main/java/camel/sample/EventhubsRouteBuilder.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package camel.sample;
+
+import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventhubsRouteBuilder extends EndpointRouteBuilder {
+
+    @Value("${namespaceName}")
+    private String namespaceName;
+
+    @Value("${eventhubsName}")
+    private String eventhubsName;
+
+    @Autowired
+    private MessageReceiver receiver;
+
+    @Override
+    public void configure() {
+        from(timer("tick")
+            .period(1000))
+            .setBody(constant("Event Test"))
+            .to(azureEventhubs(namespaceName + "/" + eventhubsName));
+
+        from(azureEventhubs(namespaceName + "/" + eventhubsName))
+            .bean(receiver)
+            .log("The content is ${body}");
+    }
+
+}

--- a/azure/camel-example-spring-boot-azure-eventhubs/src/main/java/camel/sample/MessageReceiver.java
+++ b/azure/camel-example-spring-boot-azure-eventhubs/src/main/java/camel/sample/MessageReceiver.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package camel.sample;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class MessageReceiver {
+
+    private static final Logger logger = LoggerFactory.getLogger(MessageReceiver.class);
+
+    public void onMessage(String message) {
+        logger.info("Received: {}", message);
+    }
+
+}

--- a/azure/camel-example-spring-boot-azure-eventhubs/src/main/java/camel/sample/SampleCamelEventhubsApplication.java
+++ b/azure/camel-example-spring-boot-azure-eventhubs/src/main/java/camel/sample/SampleCamelEventhubsApplication.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package camel.sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SampleCamelEventhubsApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SampleCamelEventhubsApplication.class, args);
+    }
+
+}
+
+

--- a/azure/camel-example-spring-boot-azure-eventhubs/src/main/resources/application.yml
+++ b/azure/camel-example-spring-boot-azure-eventhubs/src/main/resources/application.yml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+camel:
+  component:
+    azure-eventhubs:
+        # connectionstring for eventhubs instance, with ;EntityPath=<eventhub-name> in the end
+      connection-string: [EVENT_HUBS_CONNECTION_STRING];EntityPath=[EVENT_HUB_NAME]
+      blob-account-name: [STORAGE_ACCOUNT_NAME]
+      blob-access-key: [STORAGE_ACCOUNT_ACCESS_KEY]
+      blob-container-name: [STORAGE_CONTAINER_NAME]
+
+namespaceName: [EVENT_HUBS_NAMESPACE]
+eventhubsName: [EVENT_HUB_NAME]

--- a/azure/camel-example-spring-boot-azure-servicebus/README.adoc
+++ b/azure/camel-example-spring-boot-azure-servicebus/README.adoc
@@ -1,0 +1,48 @@
+== Spring Boot Example with Azure Service Bus
+
+=== Introduction
+
+This example demonstrates how you can use the Camel Azure Service Bus Starter component.
+
+NOTE: Running this sample will be charged by Azure. You can check the usage and bill at this https://azure.microsoft.com/get-started/azure-portal/[link].
+
+=== Create Service Bus on Azure
+
+Create an Azure Service Bus namespace and queue by following this https://learn.microsoft.com/azure/service-bus-messaging/service-bus-quickstart-portal[link].
+
+=== Configuration
+
+You need to configure the details in the file:
+
+`src/main/resources/application.yml`
+
+=== How to run
+
+Run this example using:
+
+[source,console]
+----
+mvn spring-boot:run
+----
+
+You should see the following output in the console.
+
+[source,console]
+----
+Received: Service Bus Test
+The content is Service Bus Test
+...
+Received: Service Bus Test
+The content is Service Bus Test
+...
+----
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/community/support/[let us know].
+
+We also love contributors, so
+https://camel.apache.org/community/contributing/[get involved] :-)
+
+The Camel riders!

--- a/azure/camel-example-spring-boot-azure-servicebus/pom.xml
+++ b/azure/camel-example-spring-boot-azure-servicebus/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <artifactId>camel-example-spring-boot-azure</artifactId>
+    <version>4.8.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>camel-example-spring-boot-azure-servicebus</artifactId>
+  <name>Camel SB Examples :: Azure Service Bus</name>
+  <description>An example showing how to work with Camel, Azure Service Bus and Spring Boot</description>
+
+  <properties>
+    <category>Cloud</category>
+  </properties>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+
+    <!-- Camel -->
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-azure-servicebus-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-endpointdsl-starter</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot-version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/azure/camel-example-spring-boot-azure-servicebus/src/main/java/camel/sample/MessageReceiver.java
+++ b/azure/camel-example-spring-boot-azure-servicebus/src/main/java/camel/sample/MessageReceiver.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package camel.sample;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MessageReceiver {
+
+    private static final Logger logger = LoggerFactory.getLogger(MessageReceiver.class);
+
+    public void onMessage(String message) {
+        logger.info("Received: {}", message);
+    }
+
+}

--- a/azure/camel-example-spring-boot-azure-servicebus/src/main/java/camel/sample/SampleCamelServiceBusApplication.java
+++ b/azure/camel-example-spring-boot-azure-servicebus/src/main/java/camel/sample/SampleCamelServiceBusApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package camel.sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SampleCamelServiceBusApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SampleCamelServiceBusApplication.class, args);
+    }
+
+}

--- a/azure/camel-example-spring-boot-azure-servicebus/src/main/java/camel/sample/ServicebusRouteBuilder.java
+++ b/azure/camel-example-spring-boot-azure-servicebus/src/main/java/camel/sample/ServicebusRouteBuilder.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package camel.sample;
+
+import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ServicebusRouteBuilder extends EndpointRouteBuilder {
+
+    @Autowired
+    private MessageReceiver receiver;
+
+    @Value("${queueName}")
+    private String queueName;
+
+    @Override
+    public void configure() {
+        from(timer("tick").period(1000))
+            .setBody(constant("Service Bus Test"))
+            .to(azureServicebus(queueName));
+
+        from(azureServicebus(queueName))
+            .bean(receiver)
+            .log("The content is ${body}");
+    }
+
+}

--- a/azure/camel-example-spring-boot-azure-servicebus/src/main/resources/application.yml
+++ b/azure/camel-example-spring-boot-azure-servicebus/src/main/resources/application.yml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+spring:
+  output:
+    ansi:
+      enabled: ALWAYS
+camel:
+  component:
+    azure-servicebus:
+        connection-string: [SERVICEBUS_CONNECTION_STRING]
+        service-bus-type: queue
+
+queueName: [SERVICEBUS_QUEUE_NAME]

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <artifactId>examples</artifactId>
+    <version>4.8.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>camel-example-spring-boot-azure</artifactId>
+  <packaging>pom</packaging>
+  <name>Camel SB Examples :: Azure</name>
+  <description>An example showing the Camel Azure component with Spring Boot</description>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
+  <!-- Spring-Boot and Camel BOM -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+          <groupId>com.redhat.camel.springboot.platform</groupId>
+          <artifactId>camel-spring-boot-bom</artifactId>
+          <version>${camel-spring-boot-version}</version>
+          <type>pom</type>
+          <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <modules>
+    <module>camel-example-spring-boot-azure-servicebus</module>
+    <module>camel-example-spring-boot-azure-eventhubs</module>
+  </modules>
+
+</project>

--- a/endpointdsl/pom.xml
+++ b/endpointdsl/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.springboot.example</groupId>
+        <artifactId>examples</artifactId>
+        <version>4.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-example-endpointdsl</artifactId>
+    <name>Camel SB Examples :: Endpoint DSL</name>
+    <description>Using type-safe Endpoint DSL</description>
+
+    <properties>
+        <category>Beginner</category>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
+                <artifactId>camel-spring-boot-bom</artifactId>
+                <version>${camel-spring-boot-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Camel -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-endpointdsl-starter</artifactId>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-spring-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/endpointdsl/readme.adoc
+++ b/endpointdsl/readme.adoc
@@ -1,0 +1,53 @@
+== Camel Example Endpoint DSL
+
+This example shows how to work with the type-safe Endpoint DSL to build Camel routes
+in Java code where endpoints are configured using a chain of Java method calls,
+instead of using the Camel endpoint URI style.
+
+The example generates messages using timer trigger, writes them to standard output.
+
+=== Camel routes
+
+The Camel route is embedded directly in the main class `MyCamelApplication` as a Spring Boot `@Bean` method.
+The route starts from a timer, that triggers every 2nd second and calls a Spring Bean `MyBean`
+which returns a message, that is routed to a stream endpoint which writes to standard output.
+
+=== How to run
+
+You can run this example using
+
+[source,bash]
+----
+mvn spring-boot:run
+----
+
+=== To get health check
+
+To show a summary of spring boot health check
+
+[source,bash]
+----
+curl -XGET -s http://localhost:8080/actuator/health
+----
+
+And you can see some info details as well
+
+[source,bash]
+----
+curl -XGET -s http://localhost:8080/actuator/info
+----
+
+See the `application.properties` to control what information to present in actuator.
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/support.html[let us know].
+
+We also love contributors, so
+https://camel.apache.org/contributing.html[get involved] :-)
+
+The Camel riders!
+
+
+

--- a/endpointdsl/src/main/java/sample/camel/MyBean.java
+++ b/endpointdsl/src/main/java/sample/camel/MyBean.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * A bean that returns a message when you call the {@link #saySomething()} method.
+ * <p/>
+ * Uses <tt>@Component("myBean")</tt> to register this bean with the name <tt>myBean</tt>
+ * that we use in the Camel route to lookup this bean.
+ */
+@Component("myBean")
+public class MyBean {
+
+    private int counter;
+
+    @Value("${greeting}")
+    private String say;
+
+    public String saySomething(String body) {
+        return String.format("%s I am invoked %d times", say, ++counter);
+    }
+
+}

--- a/endpointdsl/src/main/java/sample/camel/MyCamelApplication.java
+++ b/endpointdsl/src/main/java/sample/camel/MyCamelApplication.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.apache.camel.builder.endpoint.LambdaEndpointRouteBuilder;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+//CHECKSTYLE:OFF
+/**
+ * A sample Spring Boot application that starts the Camel routes.
+ */
+@SpringBootApplication
+public class MyCamelApplication {
+
+    /**
+     * A main method to start this application.
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(MyCamelApplication.class, args);
+    }
+
+    // embed route directly using type-safe endpoint-dsl using java lambda style
+    @Bean
+    public LambdaEndpointRouteBuilder myRoute() {
+        return rb -> rb
+                .from(rb.timer("timer").period(2000))
+                    .to(rb.bean("myBean").method("saySomething"))
+                    .log("${body}");
+    }
+
+}
+//CHECKSTYLE:ON

--- a/endpointdsl/src/main/resources/application.properties
+++ b/endpointdsl/src/main/resources/application.properties
@@ -1,0 +1,22 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+# the name of Camel
+camel.springboot.name = MyCamel
+
+# what to say
+greeting = Hello World

--- a/endpointdsl/src/test/java/sample/camel/MyCamelApplicationJUnit5Test.java
+++ b/endpointdsl/src/test/java/sample/camel/MyCamelApplicationJUnit5Test.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@CamelSpringBootTest
+@SpringBootTest(classes = MyCamelApplication.class)
+public class MyCamelApplicationJUnit5Test {
+
+    @Autowired
+    private CamelContext camelContext;
+
+    @Test
+    public void shouldProduceMessages() throws Exception {
+        // we expect that one or more messages is automatic done by the Camel
+        // route as it uses a timer to trigger
+        NotifyBuilder notify = new NotifyBuilder(camelContext).whenDone(1).create();
+
+        assertTrue(notify.matches(10, TimeUnit.SECONDS));
+    }
+
+}

--- a/openapi-contract-first/daisy.json
+++ b/openapi-contract-first/daisy.json
@@ -1,0 +1,4 @@
+{
+  "id": 555,
+  "name": "Daisy the parrot"
+}

--- a/openapi-contract-first/pom.xml
+++ b/openapi-contract-first/pom.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.springboot.example</groupId>
+        <artifactId>examples</artifactId>
+        <version>4.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-example-spring-boot-openapi-contract-first</artifactId>
+    <name>Camel SB Examples :: OpenAPI Contract First</name>
+    <description>Contract First OpenAPI example</description>
+
+    <properties>
+        <category>Rest</category>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
+                <artifactId>camel-spring-boot-bom</artifactId>
+                <version>${camel-spring-boot-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Camel -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-spring-boot-starter</artifactId>
+        </dependency>
+        <!-- openapi support -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-rest-openapi-starter</artifactId>
+        </dependency>
+        <!-- json support -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-jackson-starter</artifactId>
+        </dependency>
+        <!-- camel to use spring http server -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-platform-http-starter</artifactId>
+        </dependency>
+        <!-- include camel developer console -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-console-starter</artifactId>
+        </dependency>
+        <!-- include JMX that allows additional information in camel developer console -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-management-starter</artifactId>
+        </dependency>
+        <!-- Camel CLI -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-cli-connector-starter</artifactId>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-spring-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.swagger.codegen.v3</groupId>
+                <artifactId>swagger-codegen-maven-plugin</artifactId>
+                <version>3.0.52</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <!-- we only want to generate the model classes for spring boot -->
+                            <language>spring</language>
+                            <library>spring-boot3</library>
+                            <inputSpec>${project.basedir}/src/main/resources/petstore.json</inputSpec>
+                            <modelPackage>sample.petstore.model</modelPackage>
+                            <generateApis>false</generateApis>
+                            <generateApiDocumentation>false</generateApiDocumentation>
+                            <generateModelDocumentation>false</generateModelDocumentation>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <generateSupportingFiles>false</generateSupportingFiles>
+                            <generateModels>true</generateModels>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- include the model classes to source folder -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>target/swagger/src/main/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- spring boot plugin -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/openapi-contract-first/readme.adoc
+++ b/openapi-contract-first/readme.adoc
@@ -1,0 +1,67 @@
+== Camel Example OpenAPI Contract First
+
+This example uses Camel to expose REST APIs from an existing OpenAPI specification (contract first).
+
+From the contract we generate Java POJO classes (using maven plugin, see `pom.xml`).
+
+In the Camel route `PetStoreRoute.java` we use Rest DSL using OpenAPI in contract-first mode.
+This makes it possible to expose all the APIs very easily, and map this to corresponding Camel
+routes via `direct:operationId` naming convention.
+
+The example uses the Petstore OpenAPI example which comes with 18 APIs. This example has only
+implemented 2 of these APIs, and to ignore the remaining APIs. This is handy during development,
+so you can implement the APIs one by one.
+
+=== How to run
+
+You can run this example using
+
+    mvn spring-boot:run
+
+=== To call the API
+
+You can call the Rest APIs such as
+
+----
+curl http://0.0.0.0:8080/api/v3/pet/123
+----
+
+Which returns information about a pet.
+
+You can also update an existing PET such:
+
+----
+curl -XPUT -H "Content-Type: application/json" --data "@daisy.json" http://0.0.0.0:8080/api/v3/pet
+----
+
+
+=== Camel CLI
+
+This application is integrated with the Camel CLI (camel-jbang) via the `camel-cli-connector-starter` dependency (see `pom.xml`).
+This allows to use the Camel CLI to manage this application, such as:
+
+    $mvn spring-boot:run
+
+And then use the CLI to see status:
+
+    $camel get
+      PID   NAME           CAMEL  PLATFORM            PROFILE  READY  STATUS   RELOAD  AGE  ROUTE  MSG/S  TOTAL  FAIL  INFLIGHT  LAST  DELTA  SINCE-LAST
+     87918  CamelPetStore  4.6.0  Spring Boot v3.2.4            1/1   Running       0   7s    3/3   0.00      0     0         0                    -/-/-
+
+To see which Rest APIs that are available in the running Camel application, you can use camel-jbang as follows:
+
+    $camel get platform-http
+
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/support.html[let us know].
+
+We also love contributors, so
+https://camel.apache.org/contributing.html[get involved] :-)
+
+The Camel riders!
+
+
+

--- a/openapi-contract-first/src/main/java/sample/petstore/MyPetStoreApplication.java
+++ b/openapi-contract-first/src/main/java/sample/petstore/MyPetStoreApplication.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.petstore;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Main class to run Spring Boot
+ */
+@SpringBootApplication
+public class MyPetStoreApplication {
+
+    /**
+     * A main method to start this application.
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(MyPetStoreApplication.class, args);
+    }
+
+}

--- a/openapi-contract-first/src/main/java/sample/petstore/PetStoreRoute.java
+++ b/openapi-contract-first/src/main/java/sample/petstore/PetStoreRoute.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.petstore;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.rest.RestBindingMode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import sample.petstore.model.Pet;
+import sample.petstore.model.Pet.StatusEnum;
+
+/**
+ * Camel routes for the PetStore example
+ */
+@Component
+public class PetStoreRoute extends RouteBuilder {
+
+    @Value("${petName}")
+    private String petName;
+
+    @Override
+    public void configure() throws Exception {
+        // turn on json binding and scan for POJO classes in the model package
+        restConfiguration().bindingMode(RestBindingMode.json)
+                .bindingPackageScan("sample.petstore.model");
+
+        rest().openApi().specification("petstore.json").missingOperation("ignore");
+
+        from("direct:getPetById")
+                .process(e -> {
+                    // build response body as POJO
+                    Pet pet = new Pet();
+                    pet.setId(e.getMessage().getHeader("petId", long.class));
+                    pet.setName(petName);
+                    pet.setStatus(StatusEnum.AVAILABLE);
+                    e.getMessage().setBody(pet);
+                });
+
+        from("direct:updatePet")
+                .process(e -> {
+                    Pet pet = e.getMessage().getBody(Pet.class);
+                    pet.setStatus(StatusEnum.PENDING);
+                });
+    }
+}

--- a/openapi-contract-first/src/main/resources/application.properties
+++ b/openapi-contract-first/src/main/resources/application.properties
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+# the name of Camel
+camel.springboot.name = CamelPetStore
+
+# application configuration
+petName = Tony the tiger
+
+# to configure logging levels
+#logging.level.org.springframework = INFO
+#logging.level.org.apache.camel.spring.boot = INFO
+#logging.level.org.apache.camel.impl = DEBUG
+#logging.level.sample.camel = DEBUG
+

--- a/openapi-contract-first/src/main/resources/petstore.json
+++ b/openapi-contract-first/src/main/resources/petstore.json
@@ -1,0 +1,1240 @@
+{
+	"openapi": "3.0.2",
+	"info": {
+		"title": "Swagger Petstore - OpenAPI 3.0",
+		"description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml) ",
+		"termsOfService": "http://swagger.io/terms/",
+		"contact": {
+			"email": "apiteam@swagger.io"
+		},
+		"license": {
+			"name": "Apache 2.0",
+			"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+		},
+		"version": "1.0.4"
+	},
+	"externalDocs": {
+		"description": "Find out more about Swagger",
+		"url": "http://swagger.io"
+	},
+	"servers": [
+		{
+			"url": "{scheme}://{host}/{basePath}",
+			"variables": {
+				"scheme": {
+					"enum": [
+						"https",
+						"http"
+					],
+					"default": "https"
+				},
+				"host": {
+					"default": "petstore3.swagger.io"
+				},
+				"basePath": {
+					"default": "/api/v3"
+				}
+			}
+		}
+	],
+	"tags": [
+		{
+			"name": "pet",
+			"description": "Everything about your Pets",
+			"externalDocs": {
+				"description": "Find out more",
+				"url": "http://swagger.io"
+			}
+		},
+		{
+			"name": "store",
+			"description": "Operations about user"
+		},
+		{
+			"name": "user",
+			"description": "Access to Petstore orders",
+			"externalDocs": {
+				"description": "Find out more about our store",
+				"url": "http://swagger.io"
+			}
+		}
+	],
+	"paths": {
+		"/pet": {
+			"put": {
+				"tags": [
+					"pet"
+				],
+				"summary": "Update an existing pet",
+				"description": "Update an existing pet by Id",
+				"operationId": "updatePet",
+				"requestBody": {
+					"description": "Update an existent pet in the store",
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Pet"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Pet"
+							}
+						},
+						"application/x-www-form-urlencoded": {
+							"schema": {
+								"$ref": "#/components/schemas/Pet"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Successful operation",
+						"content": {
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Pet"
+								}
+							},
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Pet"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid ID supplied"
+					},
+					"404": {
+						"description": "Pet not found"
+					},
+					"405": {
+						"description": "Validation exception"
+					}
+				},
+				"security": [
+					{
+						"petstore_auth": [
+							"write:pets",
+							"read:pets"
+						]
+					}
+				]
+			},
+			"post": {
+				"tags": [
+					"pet"
+				],
+				"summary": "Add a new pet to the store",
+				"description": "Add a new pet to the store",
+				"operationId": "addPet",
+				"requestBody": {
+					"description": "Create a new pet in the store",
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Pet"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Pet"
+							}
+						},
+						"application/x-www-form-urlencoded": {
+							"schema": {
+								"$ref": "#/components/schemas/Pet"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"description": "Successful operation",
+						"content": {
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Pet"
+								}
+							},
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Pet"
+								}
+							}
+						}
+					},
+					"405": {
+						"description": "Invalid input"
+					}
+				},
+				"security": [
+					{
+						"petstore_auth": [
+							"write:pets",
+							"read:pets"
+						]
+					}
+				]
+			}
+		},
+		"/pet/findByStatus": {
+			"get": {
+				"tags": [
+					"pet"
+				],
+				"summary": "Finds Pets by status",
+				"description": "Multiple status values can be provided with comma separated strings",
+				"operationId": "findPetsByStatus",
+				"parameters": [
+					{
+						"name": "status",
+						"in": "query",
+						"description": "Status values that need to be considered for filter",
+						"required": false,
+						"explode": true,
+						"schema": {
+							"type": "string",
+							"default": "available",
+							"enum": [
+								"available",
+								"pending",
+								"sold"
+							]
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"content": {
+							"application/xml": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/Pet"
+									}
+								}
+							},
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/Pet"
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid status value"
+					}
+				},
+				"security": [
+					{
+						"petstore_auth": [
+							"write:pets",
+							"read:pets"
+						]
+					}
+				]
+			}
+		},
+		"/pet/findByTags": {
+			"get": {
+				"tags": [
+					"pet"
+				],
+				"summary": "Finds Pets by tags",
+				"description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+				"operationId": "findPetsByTags",
+				"parameters": [
+					{
+						"name": "tags",
+						"in": "query",
+						"description": "Tags to filter by",
+						"required": false,
+						"explode": true,
+						"schema": {
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"content": {
+							"application/xml": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/Pet"
+									}
+								}
+							},
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/Pet"
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid tag value"
+					}
+				},
+				"security": [
+					{
+						"petstore_auth": [
+							"write:pets",
+							"read:pets"
+						]
+					}
+				]
+			}
+		},
+		"/pet/{petId}": {
+			"get": {
+				"tags": [
+					"pet"
+				],
+				"summary": "Find pet by ID",
+				"description": "Returns a single pet",
+				"operationId": "getPetById",
+				"parameters": [
+					{
+						"name": "petId",
+						"in": "path",
+						"description": "ID of pet to return",
+						"required": true,
+						"schema": {
+							"type": "integer",
+							"format": "int64"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"content": {
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Pet"
+								}
+							},
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Pet"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid ID supplied"
+					},
+					"404": {
+						"description": "Pet not found"
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					},
+					{
+						"petstore_auth": [
+							"write:pets",
+							"read:pets"
+						]
+					}
+				]
+			},
+			"post": {
+				"tags": [
+					"pet"
+				],
+				"summary": "Updates a pet in the store with form data",
+				"description": "",
+				"operationId": "updatePetWithForm",
+				"parameters": [
+					{
+						"name": "petId",
+						"in": "path",
+						"description": "ID of pet that needs to be updated",
+						"required": true,
+						"schema": {
+							"type": "integer",
+							"format": "int64"
+						}
+					},
+					{
+						"name": "name",
+						"in": "query",
+						"description": "Name of pet that needs to be updated",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "status",
+						"in": "query",
+						"description": "Status of pet that needs to be updated",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"405": {
+						"description": "Invalid input"
+					}
+				},
+				"security": [
+					{
+						"petstore_auth": [
+							"write:pets",
+							"read:pets"
+						]
+					}
+				]
+			},
+			"delete": {
+				"tags": [
+					"pet"
+				],
+				"summary": "Deletes a pet",
+				"description": "",
+				"operationId": "deletePet",
+				"parameters": [
+					{
+						"name": "api_key",
+						"in": "header",
+						"description": "",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "petId",
+						"in": "path",
+						"description": "Pet id to delete",
+						"required": true,
+						"schema": {
+							"type": "integer",
+							"format": "int64"
+						}
+					}
+				],
+				"responses": {
+					"400": {
+						"description": "Invalid pet value"
+					}
+				},
+				"security": [
+					{
+						"petstore_auth": [
+							"write:pets",
+							"read:pets"
+						]
+					}
+				]
+			}
+		},
+		"/pet/{petId}/uploadImage": {
+			"post": {
+				"tags": [
+					"pet"
+				],
+				"summary": "uploads an image",
+				"description": "",
+				"operationId": "uploadFile",
+				"parameters": [
+					{
+						"name": "petId",
+						"in": "path",
+						"description": "ID of pet to update",
+						"required": true,
+						"schema": {
+							"type": "integer",
+							"format": "int64"
+						}
+					},
+					{
+						"name": "additionalMetadata",
+						"in": "query",
+						"description": "Additional Metadata",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/octet-stream": {
+							"schema": {
+								"type": "string",
+								"format": "binary"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiResponse"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"petstore_auth": [
+							"write:pets",
+							"read:pets"
+						]
+					}
+				]
+			}
+		},
+		"/store/inventory": {
+			"get": {
+				"tags": [
+					"store"
+				],
+				"summary": "Returns pet inventories by status",
+				"description": "Returns a map of status codes to quantities",
+				"operationId": "getInventory",
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "integer",
+										"format": "int32"
+									}
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			}
+		},
+		"/store/order": {
+			"post": {
+				"tags": [
+					"store"
+				],
+				"summary": "Place an order for a pet",
+				"description": "Place a new order in the store",
+				"operationId": "placeOrder",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Order"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Order"
+							}
+						},
+						"application/x-www-form-urlencoded": {
+							"schema": {
+								"$ref": "#/components/schemas/Order"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Order"
+								}
+							}
+						}
+					},
+					"405": {
+						"description": "Invalid input"
+					}
+				}
+			}
+		},
+		"/store/order/{orderId}": {
+			"get": {
+				"tags": [
+					"store"
+				],
+				"summary": "Find purchase order by ID",
+				"description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
+				"operationId": "getOrderById",
+				"parameters": [
+					{
+						"name": "orderId",
+						"in": "path",
+						"description": "ID of order that needs to be fetched",
+						"required": true,
+						"schema": {
+							"type": "integer",
+							"format": "int64"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"content": {
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Order"
+								}
+							},
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Order"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid ID supplied"
+					},
+					"404": {
+						"description": "Order not found"
+					}
+				}
+			},
+			"delete": {
+				"tags": [
+					"store"
+				],
+				"summary": "Delete purchase order by ID",
+				"description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+				"operationId": "deleteOrder",
+				"parameters": [
+					{
+						"name": "orderId",
+						"in": "path",
+						"description": "ID of the order that needs to be deleted",
+						"required": true,
+						"schema": {
+							"type": "integer",
+							"format": "int64"
+						}
+					}
+				],
+				"responses": {
+					"400": {
+						"description": "Invalid ID supplied"
+					},
+					"404": {
+						"description": "Order not found"
+					}
+				}
+			}
+		},
+		"/user": {
+			"post": {
+				"tags": [
+					"user"
+				],
+				"summary": "Create user",
+				"description": "This can only be done by the logged in user.",
+				"operationId": "createUser",
+				"requestBody": {
+					"description": "Created user object",
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/User"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/User"
+							}
+						},
+						"application/x-www-form-urlencoded": {
+							"schema": {
+								"$ref": "#/components/schemas/User"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"description": "successful operation",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/User"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/User"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/user/createWithList": {
+			"post": {
+				"tags": [
+					"user"
+				],
+				"summary": "Creates list of users with given input array",
+				"description": "Creates list of users with given input array",
+				"operationId": "createUsersWithListInput",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "array",
+								"items": {
+									"$ref": "#/components/schemas/User"
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Successful operation",
+						"content": {
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/User"
+								}
+							},
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/User"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "successful operation"
+					}
+				}
+			}
+		},
+		"/user/login": {
+			"get": {
+				"tags": [
+					"user"
+				],
+				"summary": "Logs user into the system",
+				"description": "",
+				"operationId": "loginUser",
+				"parameters": [
+					{
+						"name": "username",
+						"in": "query",
+						"description": "The user name for login",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "password",
+						"in": "query",
+						"description": "The password for login in clear text",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"headers": {
+							"X-Rate-Limit": {
+								"description": "calls per hour allowed by the user",
+								"schema": {
+									"type": "integer",
+									"format": "int32"
+								}
+							},
+							"X-Expires-After": {
+								"description": "date in UTC when toekn expires",
+								"schema": {
+									"type": "string",
+									"format": "date-time"
+								}
+							}
+						},
+						"content": {
+							"application/xml": {
+								"schema": {
+									"type": "string"
+								}
+							},
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid username/password supplied"
+					}
+				}
+			}
+		},
+		"/user/logout": {
+			"get": {
+				"tags": [
+					"user"
+				],
+				"summary": "Logs out current logged in user session",
+				"description": "",
+				"operationId": "logoutUser",
+				"parameters": [],
+				"responses": {
+					"default": {
+						"description": "successful operation"
+					}
+				}
+			}
+		},
+		"/user/{username}": {
+			"get": {
+				"tags": [
+					"user"
+				],
+				"summary": "Get user by user name",
+				"description": "",
+				"operationId": "getUserByName",
+				"parameters": [
+					{
+						"name": "username",
+						"in": "path",
+						"description": "The name that needs to be fetched. Use user1 for testing. ",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"content": {
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/User"
+								}
+							},
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/User"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid username supplied"
+					},
+					"404": {
+						"description": "User not found"
+					}
+				}
+			},
+			"put": {
+				"tags": [
+					"user"
+				],
+				"summary": "Update user",
+				"description": "This can only be done by the logged in user.",
+				"operationId": "updateUser",
+				"parameters": [
+					{
+						"name": "username",
+						"in": "path",
+						"description": "name that need to be deleted",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "Update an existent user in the store",
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/User"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/User"
+							}
+						},
+						"application/x-www-form-urlencoded": {
+							"schema": {
+								"$ref": "#/components/schemas/User"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"description": "successful operation"
+					}
+				}
+			},
+			"delete": {
+				"tags": [
+					"user"
+				],
+				"summary": "Delete user",
+				"description": "This can only be done by the logged in user.",
+				"operationId": "deleteUser",
+				"parameters": [
+					{
+						"name": "username",
+						"in": "path",
+						"description": "The name that needs to be deleted",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"400": {
+						"description": "Invalid username supplied"
+					},
+					"404": {
+						"description": "User not found"
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"Order": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64",
+						"example": 10
+					},
+					"petId": {
+						"type": "integer",
+						"format": "int64",
+						"example": 198772
+					},
+					"quantity": {
+						"type": "integer",
+						"format": "int32",
+						"example": 7
+					},
+					"shipDate": {
+						"type": "string",
+						"format": "date-time"
+					},
+					"status": {
+						"type": "string",
+						"description": "Order Status",
+						"example": "approved",
+						"enum": [
+							"placed",
+							"approved",
+							"delivered"
+						]
+					},
+					"complete": {
+						"type": "boolean"
+					}
+				},
+				"xml": {
+					"name": "order"
+				}
+			},
+			"Customer": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64",
+						"example": 100000
+					},
+					"username": {
+						"type": "string",
+						"example": "fehguy"
+					},
+					"address": {
+						"type": "array",
+						"xml": {
+							"name": "addresses",
+							"wrapped": true
+						},
+						"items": {
+							"$ref": "#/components/schemas/Address"
+						}
+					}
+				},
+				"xml": {
+					"name": "customer"
+				}
+			},
+			"Address": {
+				"type": "object",
+				"properties": {
+					"street": {
+						"type": "string",
+						"example": "437 Lytton"
+					},
+					"city": {
+						"type": "string",
+						"example": "Palo Alto"
+					},
+					"state": {
+						"type": "string",
+						"example": "CA"
+					},
+					"zip": {
+						"type": "string",
+						"example": "94301"
+					}
+				},
+				"xml": {
+					"name": "address"
+				}
+			},
+			"Category": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64",
+						"example": 1
+					},
+					"name": {
+						"type": "string",
+						"example": "Dogs"
+					}
+				},
+				"xml": {
+					"name": "category"
+				}
+			},
+			"User": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64",
+						"example": 10
+					},
+					"username": {
+						"type": "string",
+						"example": "theUser"
+					},
+					"firstName": {
+						"type": "string",
+						"example": "John"
+					},
+					"lastName": {
+						"type": "string",
+						"example": "James"
+					},
+					"email": {
+						"type": "string",
+						"example": "john@email.com"
+					},
+					"password": {
+						"type": "string",
+						"example": "12345"
+					},
+					"phone": {
+						"type": "string",
+						"example": "12345"
+					},
+					"userStatus": {
+						"type": "integer",
+						"description": "User Status",
+						"format": "int32",
+						"example": 1
+					}
+				},
+				"xml": {
+					"name": "user"
+				}
+			},
+			"Tag": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64"
+					},
+					"name": {
+						"type": "string"
+					}
+				},
+				"xml": {
+					"name": "tag"
+				}
+			},
+			"Pet": {
+				"required": [
+					"name",
+					"photoUrls"
+				],
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64",
+						"example": 10
+					},
+					"name": {
+						"type": "string",
+						"example": "doggie"
+					},
+					"category": {
+						"$ref": "#/components/schemas/Category"
+					},
+					"photoUrls": {
+						"type": "array",
+						"xml": {
+							"wrapped": true
+						},
+						"items": {
+							"type": "string",
+							"xml": {
+								"name": "photoUrl"
+							}
+						}
+					},
+					"tags": {
+						"type": "array",
+						"xml": {
+							"wrapped": true
+						},
+						"items": {
+							"$ref": "#/components/schemas/Tag"
+						}
+					},
+					"status": {
+						"type": "string",
+						"description": "pet status in the store",
+						"enum": [
+							"available",
+							"pending",
+							"sold"
+						]
+					}
+				},
+				"xml": {
+					"name": "pet"
+				}
+			},
+			"ApiResponse": {
+				"type": "object",
+				"properties": {
+					"code": {
+						"type": "integer",
+						"format": "int32"
+					},
+					"type": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					}
+				},
+				"xml": {
+					"name": "##default"
+				}
+			}
+		},
+		"requestBodies": {
+			"Pet": {
+				"description": "Pet object that needs to be added to the store",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "#/components/schemas/Pet"
+						}
+					},
+					"application/xml": {
+						"schema": {
+							"$ref": "#/components/schemas/Pet"
+						}
+					}
+				}
+			},
+			"UserArray": {
+				"description": "List of user object",
+				"content": {
+					"application/json": {
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/components/schemas/User"
+							}
+						}
+					}
+				}
+			}
+		},
+		"securitySchemes": {
+			"petstore_auth": {
+				"type": "oauth2",
+				"flows": {
+					"implicit": {
+						"authorizationUrl": "https://petstore3.swagger.io/oauth/authorize",
+						"scopes": {
+							"write:pets": "modify pets in your account",
+							"read:pets": "read your pets"
+						}
+					}
+				}
+			},
+			"api_key": {
+				"type": "apiKey",
+				"name": "api_key",
+				"in": "header"
+			}
+		}
+	}
+}

--- a/platform-http/README.adoc
+++ b/platform-http/README.adoc
@@ -1,0 +1,122 @@
+== Spring Boot Example with Camel REST DSL and Platform HTTP
+
+=== Introduction
+
+This example illustrates how to use https://projects.spring.io/spring-boot/[Spring Boot] with http://camel.apache.org[Camel]. It provides a simple REST service that is created with http://camel.apache.org/rest-dsl.html[Camel REST DSL] and https://camel.apache.org/components/3.18.x/platform-http-component.html[platform-http].
+
+The project uses the `camel-spring-boot-starter` dependency, a Spring Boot starter dependency for Camel that simplifies the Maven configuration. 
+
+The project also uses `camel-servlet-starter` component as the implementation for platform-http-engine.
+
+=== Build
+
+You can build this example using:
+
+    $ mvn package
+
+=== Run
+
+You can run this example using:
+
+    $ mvn spring-boot:run
+
+You should see the following output when the application is launched:
+
+[source,text]
+----
+
+  .   ____          _            __ _ _
+ /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
+( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
+ \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
+  '  |____| .__|_| |_|_| |_\__, | / / / /
+ =========|_|==============|___/=/_/_/_/
+ ...
+2022-09-05 12:00:31.101  INFO 16692 --- [           main] o.a.c.c.s.CamelHttpTransportServlet      : Initialized CamelHttpTransportServlet[name=CamelServlet, contextPath=]
+2022-09-05 12:00:31.113  INFO 16692 --- [           main] io.undertow                              : starting server: Undertow - 2.2.19.Final
+2022-09-05 12:00:31.128  INFO 16692 --- [           main] org.xnio                                 : XNIO version 3.8.7.Final
+2022-09-05 12:00:31.144  INFO 16692 --- [           main] org.xnio.nio                             : XNIO NIO Implementation Version 3.8.7.Final
+2022-09-05 12:00:31.354  INFO 16692 --- [           main] org.jboss.threads                        : JBoss Threads version 3.1.0.Final
+2022-09-05 12:00:31.453  INFO 16692 --- [           main] o.s.b.w.e.undertow.UndertowWebServer     : Undertow started on port(s) 8080 (http)
+2022-09-05 12:00:31.955  INFO 16692 --- [           main] o.a.c.impl.engine.AbstractCamelContext   : Apache Camel 4.0.0-SNAPSHOT (MyCamel) is starting
+2022-09-05 12:00:31.989  INFO 16692 --- [           main] o.a.c.impl.engine.AbstractCamelContext   : Routes startup (started:7)
+2022-09-05 12:00:31.989  INFO 16692 --- [           main] o.a.c.impl.engine.AbstractCamelContext   :     Started route1 (direct://test)
+2022-09-05 12:00:31.989  INFO 16692 --- [           main] o.a.c.impl.engine.AbstractCamelContext   :     Started route2 (rest://get:/todos)
+2022-09-05 12:00:31.989  INFO 16692 --- [           main] o.a.c.impl.engine.AbstractCamelContext   :     Started route3 (rest://get:/todos:/%7Bid%7D)
+2022-09-05 12:00:31.990  INFO 16692 --- [           main] o.a.c.impl.engine.AbstractCamelContext   :     Started route4 (rest://patch:/todos:/%7Bid%7D)
+2022-09-05 12:00:31.990  INFO 16692 --- [           main] o.a.c.impl.engine.AbstractCamelContext   :     Started route5 (rest://post:/todos)
+2022-09-05 12:00:31.990  INFO 16692 --- [           main] o.a.c.impl.engine.AbstractCamelContext   :     Started route6 (rest://delete:/todos)
+2022-09-05 12:00:31.991  INFO 16692 --- [           main] o.a.c.impl.engine.AbstractCamelContext   :     Started route7 (rest://delete:/todos:/%7Bid%7D)
+2022-09-05 12:00:31.992  INFO 16692 --- [           main] o.a.c.impl.engine.AbstractCamelContext   : Apache Camel 4.0.0-SNAPSHOT (MyCamel) started in 552ms (build:95ms init:421ms start:36ms)
+2022-09-05 12:00:32.005  INFO 16692 --- [           main] o.a.c.example.springboot.Application     : Started Application in 13.737 seconds (JVM running for 14.657)
+----
+
+After the Spring Boot application is started, you can execute the following HTTP requests:
+
+Create a TODO
+
+[source,text]
+----
+$ curl -d '{"title":"Todo title", "completed":"false", "order": 1, "url":""}' -H "Content-Type: application/json" -X POST http://localhost:8080/todos
+----
+
+The command will produce the following output:
+
+[source,json]
+----
+{"id":1,"title":"Todo title","completed":false,"order":1,"url":""}
+----
+
+Retrieve all TODOs
+
+[source,text]
+----
+$ curl http://localhost:8080/todos
+----
+
+The command will produce the following output:
+
+[source,json]
+----
+[{"id":1,"title":"Todo title","completed":false,"order":1,"url":""}]
+----
+
+Update one TODO
+
+[source,text]
+----
+$ curl -d '{"title":"Todo title", "completed":"true", "order": 1, "url":""}' -H "Content-Type: application/json" -X PATCH http://localhost:8080/todos/1
+----
+
+The command will produce the following output:
+
+[source,json]
+----
+{"id":1,"title":"Todo title","completed":true,"order":1,"url":""}
+----
+
+Delete completed TODOs
+
+[source,text]
+----
+$ curl -X "DELETE" http://localhost:8080/todos
+----
+
+The command will produce the following output:
+
+[source,json]
+----
+1
+----
+
+The Spring Boot application can be stopped pressing `[CTRL] + [C]` in the shell.
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/community/support/[let us know].
+
+We also love contributors, so
+https://camel.apache.org/community/contributing/[get involved] :-)
+
+The Camel riders!

--- a/platform-http/pom.xml
+++ b/platform-http/pom.xml
@@ -1,0 +1,101 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.springboot.example</groupId>
+        <artifactId>examples</artifactId>
+        <version>4.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-example-spring-boot-platform-http</artifactId>
+    <name>Camel SB Examples :: REST DSL and Platform HTTP</name>
+    <description>An example showing Camel REST DSL with platform HTTP</description>
+
+    <properties>
+        <category>Rest</category>
+    </properties>
+
+    <!-- Spring-Boot and Camel BOM -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
+                <artifactId>camel-spring-boot-bom</artifactId>
+                <version>${camel-spring-boot-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Camel -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-platform-http-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-jackson-starter</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-junit5</artifactId>
+            <version>${camel-version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/platform-http/src/main/java/org/apache/camel/example/springboot/Application.java
+++ b/platform-http/src/main/java/org/apache/camel/example/springboot/Application.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example.springboot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+// CHECKSTYLE:OFF
+@SpringBootApplication
+public class Application {
+
+    /**
+     * Main method to start the application.
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}
+// CHECKSTYLE:ON

--- a/platform-http/src/main/java/org/apache/camel/example/springboot/CamelRouter.java
+++ b/platform-http/src/main/java/org/apache/camel/example/springboot/CamelRouter.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example.springboot;
+
+import static org.apache.camel.model.rest.RestParamType.body;
+import static org.apache.camel.model.rest.RestParamType.path;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.rest.RestBindingMode;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * A simple Camel REST DSL route.
+ */
+@Component
+public class CamelRouter extends RouteBuilder {
+
+	@Override
+	public void configure() throws Exception {
+		restConfiguration()
+				.bindingMode(RestBindingMode.json);
+
+		// @formatter:off
+        rest("/todos").description("Todo REST service")
+            .consumes("application/json")
+            .produces("application/json")
+
+            .get().description("Find all todos").outType(Todo[].class)
+                .responseMessage().code(200).message("All todos successfully returned").endResponseMessage()
+                .to("bean:todoService?method=listAll")
+        
+            .get("/{id}").description("Find todo by ID")
+                .outType(Todo.class)
+                .param().name("id").type(path).description("The ID of the todo").dataType("long").endParam()
+                .responseMessage().code(200).message("Todo successfully returned").endResponseMessage()
+                .to("bean:todoService?method=findById(${header.id})")
+
+            .patch("/{id}").description("Update a todo").type(Todo.class)
+                .param().name("id").type(path).description("The ID of the todo to update").dataType("long").endParam()
+                .param().name("body").type(body).description("The todo to update").endParam()
+                .responseMessage().code(204).message("Todo successfully updated").endResponseMessage()
+				.to("bean:todoService?method=update(${body}, ${header.id})")
+
+            .post().description("Create a todo").type(Todo.class)
+                .param().name("body").type(body).endParam()
+                .responseMessage().code(201).message("Todo successfully created").endResponseMessage()
+                .to("bean:todoService?method=create")
+
+            .delete().description("Delete completed todos")
+                .responseMessage().code(200).message("Todos deleted").endResponseMessage()
+                .to("bean:todoService?method=deleteCompleted")
+
+            .delete("/{id}").description("Delete by id")
+                .param().name("id").type(path).description("The ID of the todo to delete").dataType("long").endParam()
+                .responseMessage().code(200).message("Todo deleted").endResponseMessage()
+                .to("bean:todoService?method=deleteOne(${header.id})");
+        // @formatter:on
+	}
+}

--- a/platform-http/src/main/java/org/apache/camel/example/springboot/Todo.java
+++ b/platform-http/src/main/java/org/apache/camel/example/springboot/Todo.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example.springboot;
+
+public class Todo {
+	private long id;
+	private String title;
+	private boolean completed;
+	private int order;
+	private String url;
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public boolean isCompleted() {
+		return completed;
+	}
+
+	public void setCompleted(boolean completed) {
+		this.completed = completed;
+	}
+
+	public int getOrder() {
+		return order;
+	}
+
+	public void setOrder(int order) {
+		this.order = order;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	@Override
+	public String toString() {
+		return "Todo{" +
+				"id=" + id +
+				", title='" + title + '\'' +
+				", completed=" + completed +
+				", order=" + order +
+				", url='" + url + '\'' +
+				'}';
+	}
+}

--- a/platform-http/src/main/java/org/apache/camel/example/springboot/TodoService.java
+++ b/platform-http/src/main/java/org/apache/camel/example/springboot/TodoService.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example.springboot;
+
+import java.util.Collection;
+
+/**
+ * Service interface for managing todos.
+ */
+public interface TodoService {
+	Collection<Todo> findNotCompleted();
+
+	Collection<Todo> findCompleted();
+
+	long deleteCompleted();
+
+	Todo findById(long id);
+
+	void create(Todo todo);
+
+	Todo update(Todo todo, long id);
+
+	void deleteOne(long id);
+
+	Collection<Todo> listAll();
+}

--- a/platform-http/src/main/java/org/apache/camel/example/springboot/TodoServiceImpl.java
+++ b/platform-http/src/main/java/org/apache/camel/example/springboot/TodoServiceImpl.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example.springboot;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+@Service("todoService")
+public class TodoServiceImpl implements TodoService {
+
+	private Map<Long, Todo> todos = new ConcurrentHashMap<>();
+	private AtomicLong counter = new AtomicLong(1);
+
+	@Override
+	public Collection<Todo> findNotCompleted() {
+		return todos.values().stream().filter(todo -> !todo.isCompleted()).collect(Collectors.toList());
+	}
+
+	@Override
+	public Collection<Todo> findCompleted() {
+		return todos.values().stream().filter(Todo::isCompleted).collect(Collectors.toList());
+	}
+
+	@Override
+	public long deleteCompleted() {
+		long completed = todos.values().stream().filter(Todo::isCompleted).count();
+
+		todos.entrySet().removeIf(entry -> entry.getValue().isCompleted());
+
+		return completed;
+	}
+
+	@Override
+	public Todo findById(long id) {
+		return todos.get(id);
+	}
+
+	@Override
+	public void create(Todo todo) {
+		todo.setId(counter.getAndIncrement());
+		todos.put(todo.getId(), todo);
+	}
+
+	@Override
+	public Todo update(Todo todo, long id) {
+		Todo persistedTodo = todos.get(id);
+		if (persistedTodo != null) {
+			persistedTodo.setCompleted(todo.isCompleted());
+			persistedTodo.setTitle(todo.getTitle());
+			persistedTodo.setOrder(todo.getOrder());
+			persistedTodo.setUrl(todo.getUrl());
+
+			return persistedTodo;
+		}
+		return null;
+	}
+
+	@Override
+	public void deleteOne(long id) {
+		todos.remove(id);
+	}
+
+	@Override
+	public Collection<Todo> listAll() {
+		return todos.values();
+	}
+}

--- a/platform-http/src/main/resources/application.properties
+++ b/platform-http/src/main/resources/application.properties
@@ -1,0 +1,19 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+# the name of Camel
+camel.springboot.name = MyCamel

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
 		<module>rest-openapi-springdoc</module>
 		<module>routetemplate</module>
 		<module>route-reload</module>
+		<module>routes-configuration</module>
 		<module>spring-boot-jta-jpa-xml</module>
 		<module>spring-boot-jta-jpa-autoconfigure</module>
 		<module>saga</module>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
 		<module>arangodb</module>
 		<module>aws2-s3</module>
 		<module>azure</module>
+		<module>endpointdsl</module>
 		<module>fhir</module>
 		<module>fhir-auth-tx</module>
 		<module>health-checks</module>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
 		<module>openapi-contract-first</module>
 		<module>opentelemetry</module>
 		<module>paho-mqtt5-shared-subscriptions</module>
+		<module>platform-http</module>
 		<module>pojo</module>
 		<module>rabbitmq</module>
 		<module>reactive-streams</module>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
 		<module>rest-openapi-simple</module>
 		<module>rest-openapi-springdoc</module>
 		<module>routetemplate</module>
+		<module>routetemplate-xml</module>
 		<module>route-reload</module>
 		<module>routes-configuration</module>
 		<module>spring-boot-jta-jpa-xml</module>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 		<module>actuator-http-metrics</module>
 		<module>amqp</module>
 		<module>amqp-salesforce</module>
+		<module>artemis</module>
 		<module>arangodb</module>
 		<module>aws2-s3</module>
 		<module>fhir</module>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 		<module>master</module>
 		<module>metrics</module>
 		<module>observation</module>
+		<module>openapi-contract-first</module>
 		<module>opentelemetry</module>
 		<module>paho-mqtt5-shared-subscriptions</module>
 		<module>pojo</module>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 	</modules>
 
 	<properties>
-		<camel-spring-boot-version>4.4.0.redhat-00006</camel-spring-boot-version>
+		<camel-spring-boot-version>4.8.0.redhat-00001</camel-spring-boot-version>
 		<skip.starting.camel.context>false</skip.starting.camel.context>
 		<javax.servlet.api.version>4.0.1</javax.servlet.api.version>
 		<jkube-maven-plugin-version>1.17.0.redhat-00001</jkube-maven-plugin-version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 		<module>artemis</module>
 		<module>arangodb</module>
 		<module>aws2-s3</module>
+		<module>azure</module>
 		<module>fhir</module>
 		<module>fhir-auth-tx</module>
 		<module>health-checks</module>

--- a/routes-configuration/pom.xml
+++ b/routes-configuration/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.springboot.example</groupId>
+        <artifactId>examples</artifactId>
+        <version>4.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-example-spring-boot-routes-configuration</artifactId>
+    <name>Camel SB Examples :: Spring Boot :: Routes Configuration</name>
+    <description>Example with global routes configuration for error handling</description>
+
+    <properties>
+        <category>Beginner</category>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
+                <artifactId>camel-spring-boot-bom</artifactId>
+                <version>${camel-spring-boot-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <!-- Camel -->
+
+        <!-- fine grained dependencies when using engine-starter -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-spring-boot-engine-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-bean-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-direct-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-log-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-timer-starter</artifactId>
+        </dependency>
+
+        <!-- xml-io with fast xml route loader -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-xml-io-dsl-starter</artifactId>
+        </dependency>
+        <!-- yaml route loader -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-yaml-dsl-starter</artifactId>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-spring-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- For debugging -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-debug-starter</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/routes-configuration/readme.adoc
+++ b/routes-configuration/readme.adoc
@@ -1,0 +1,31 @@
+== Camel Example Spring Boot Route Configuration
+
+This example shows how Camel is capable of loading routes during startup using the new route loader system.
+The route loader has support for loading routes in XML, Java and YAML (other languages to be added).
+
+In this example the focus is on how you can use global _routes configuration_ with the DSL to separate
+error handling (and other cross routes functionality) from all your routes.
+
+This example has one route in Java, XML and YAML. Each of those routes refer to a
+specific route configuration, which is also _coded_ in the same language as the route.
+But this is not required, you can use Java to code your route configurations for
+advanced error handling, and then _code_ your routes in other languages such as XML or YAML.
+
+=== How to run
+
+You can run this example using
+
+    mvn spring-boot:run
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/support.html[let us know].
+
+We also love contributors, so
+https://camel.apache.org/contributing.html[get involved] :-)
+
+The Camel riders!
+
+
+

--- a/routes-configuration/src/main/java/sample/camel/MyCamelApplication.java
+++ b/routes-configuration/src/main/java/sample/camel/MyCamelApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+//CHECKSTYLE:OFF
+/**
+ * A sample Spring Boot application that starts the Camel routes.
+ */
+@SpringBootApplication
+public class MyCamelApplication {
+
+    /**
+     * A main method to start this application.
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(MyCamelApplication.class, args);
+    }
+
+}
+//CHECKSTYLE:ON

--- a/routes-configuration/src/main/java/sample/camel/MyJavaErrorHandler.java
+++ b/routes-configuration/src/main/java/sample/camel/MyJavaErrorHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.apache.camel.builder.RouteConfigurationBuilder;
+import org.springframework.stereotype.Component;
+
+// Use @Component to let spring boot discover this class automatic
+@Component
+public class MyJavaErrorHandler extends RouteConfigurationBuilder {
+
+    @Override
+    public void configuration() throws Exception {
+        routeConfiguration("javaError")
+            .onException(Exception.class).handled(true)
+            .log("Java WARN: ${exception.message}");
+    }
+}

--- a/routes-configuration/src/main/java/sample/camel/MyJavaRouteBuilder.java
+++ b/routes-configuration/src/main/java/sample/camel/MyJavaRouteBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import java.util.Random;
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.stereotype.Component;
+
+// Use @Component to let spring boot discover this class automatic
+@Component
+public class MyJavaRouteBuilder extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from("timer:java?period=2s")
+            // refer to the route configuration by the id to use for this route
+            .routeConfigurationId("javaError")
+            .setBody(method(MyJavaRouteBuilder.class, "randomNumber"))
+            .log("Random number ${body}")
+            .filter(simple("${body} < 30"))
+                .throwException(new IllegalArgumentException("The number is too low"));
+    }
+
+    public static int randomNumber() {
+        return new Random().nextInt(100);
+    }
+}

--- a/routes-configuration/src/main/resources/application.yaml
+++ b/routes-configuration/src/main/resources/application.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+camel:
+  springboot:
+    name: MyCamel
+
+    # keep Camel running
+    main-run-controller: true
+
+    # verbose summary so you can see the pairing of routes and routes configurations
+    startup-summary-level: verbose
+
+    # dump routes as XML (routes are coded in different DSLs but can be dumped as XML)
+    dump-routes: true
+
+    # which directory(s) to scan for routes/route-configurations which can be xml, yaml or java files
+    routes-include-pattern: classpath:myroutes/*,classpath:myerror/*,classpath:myinterceptor/*

--- a/routes-configuration/src/main/resources/myerror/xml-error.xml
+++ b/routes-configuration/src/main/resources/myerror/xml-error.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<routeConfiguration id="xmlError">
+    <onException>
+        <exception>java.lang.Exception</exception>
+        <handled><constant>true</constant></handled>
+        <log message="XML WARN: ${exception.message}" id="inOnException"/>
+    </onException>
+</routeConfiguration>

--- a/routes-configuration/src/main/resources/myerror/yaml-error.yaml
+++ b/routes-configuration/src/main/resources/myerror/yaml-error.yaml
@@ -1,0 +1,28 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+- routeConfiguration:
+    id: "yamlError"
+    onException:
+    - onException:
+        handled:
+          constant: "true"
+        exception:
+          - "java.lang.Exception"
+        steps:
+          - log:
+              message: "YAML WARN ${exception.message}"

--- a/routes-configuration/src/main/resources/myinterceptor/xml-interceptor.xml
+++ b/routes-configuration/src/main/resources/myinterceptor/xml-interceptor.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<routeConfiguration id="xmlInterceptor">
+    <interceptFrom uri="*">
+        <log message="Message intercepted from ${header.CamelInterceptedEndpoint}" id="inXmlInterceptor"/>
+    </interceptFrom>
+</routeConfiguration>

--- a/routes-configuration/src/main/resources/myroutes/my-xml-route.xml
+++ b/routes-configuration/src/main/resources/myroutes/my-xml-route.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<!--
+    if you want to have multiple routes, you can either have multiple files with 1 <route> per file or
+    you can use <routes> as root tag, such as <routes><route>...</route><route>...</route></routes>
+-->
+
+<!-- refer to the route configuration by the id to use for this route -->
+<route routeConfigurationId="xmlError,xmlInterceptor">
+    <from uri="timer:xml?period=5s"/>
+    <log message="I am XML"/>
+    <throwException exceptionType="java.lang.Exception" message="Some kind of XML error"/>
+</route>

--- a/routes-configuration/src/main/resources/myroutes/my-yaml-route.camel.yaml
+++ b/routes-configuration/src/main/resources/myroutes/my-yaml-route.camel.yaml
@@ -1,0 +1,33 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+- route:
+    # refer to the route configuration by the id to use for this route
+    routeConfigurationId: "yamlError"
+    from:
+      uri: "timer:yaml?period=3s&includeMetadata=true"
+      steps:
+        - setBody:
+            simple: "Timer fired ${header.CamelTimerCounter} times"
+        - to:
+            uri: "log:yaml"
+            parameters:
+              showBodyType: false
+              showExchangePattern: false
+        - throwException:
+            exceptionType: "java.lang.IllegalArgumentException"
+            message: "Error from yaml"

--- a/routes-configuration/src/test/java/sample/camel/MyCamelApplicationJUnit5Test.java
+++ b/routes-configuration/src/test/java/sample/camel/MyCamelApplicationJUnit5Test.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@CamelSpringBootTest
+@SpringBootTest(classes = MyCamelApplication.class)
+public class MyCamelApplicationJUnit5Test {
+
+    @Autowired
+    private CamelContext camelContext;
+
+    @Test
+    public void shouldProduceMessages() throws Exception {
+        // we expect that one or more messages is automatic done by the Camel
+        // route as it uses a timer to trigger
+        NotifyBuilder notify = new NotifyBuilder(camelContext).whenDone(1).create();
+
+        assertTrue(notify.matches(10, TimeUnit.SECONDS));
+    }
+
+}

--- a/routetemplate-xml/README.adoc
+++ b/routetemplate-xml/README.adoc
@@ -1,0 +1,37 @@
+== Camel Example Spring Boot Route Template in XML
+
+This examples shows how to use Route Templates (parameterized routes) to specify a skeleton route
+which can be used for creating and adding new routes via parameters in pure XML.
+
+The route template is defined via XML DSL (RouteBuilder) in the resource `templates/my-route-templates.xml`.
+
+The resource `builders/my-template-builder.xml` is used to create two routes from the template using different set of parameters by leveraging the XML DSL.
+
+=== Build
+
+You will need to compile this example first:
+
+----
+$ mvn compile
+----
+
+=== How to run
+
+You can run this example using
+
+----
+$ mvn spring-boot:run
+----
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/community/support/[let us know].
+
+We also love contributors, so
+https://camel.apache.org/community/contributing/[get involved] :-)
+
+The Camel riders!
+
+
+

--- a/routetemplate-xml/pom.xml
+++ b/routetemplate-xml/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.springboot.example</groupId>
+        <artifactId>examples</artifactId>
+        <version>4.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-example-spring-boot-routetemplate-xml</artifactId>
+    <name>Camel SB Examples :: Spring Boot :: Route Template :: XML</name>
+    <description>How to use route templates (parameterized routes) in XML</description>
+
+    <properties>
+        <category>Beginner</category>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
+                <artifactId>camel-spring-boot-bom</artifactId>
+                <version>${camel-spring-boot-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Camel -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-quartz-starter</artifactId>
+        </dependency>
+        <!-- xml dsl -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-xml-io-dsl-starter</artifactId>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-spring-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/routetemplate-xml/src/main/java/sample/camel/MyCamelApplication.java
+++ b/routetemplate-xml/src/main/java/sample/camel/MyCamelApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+//CHECKSTYLE:OFF
+/**
+ * A sample Spring Boot application that starts the Camel routes.
+ */
+@SpringBootApplication
+public class MyCamelApplication {
+
+    /**
+     * A main method to start this application.
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(MyCamelApplication.class, args);
+    }
+
+}
+//CHECKSTYLE:ON

--- a/routetemplate-xml/src/main/resources/application.yaml
+++ b/routetemplate-xml/src/main/resources/application.yaml
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+camel:
+  springboot:
+    name: MyCamel
+    routes-include-pattern: classpath:templates/*.xml,classpath:builders/*.xml

--- a/routetemplate-xml/src/main/resources/builders/my-builder.xml
+++ b/routetemplate-xml/src/main/resources/builders/my-builder.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<templatedRoutes id="camel" xmlns="http://camel.apache.org/schema/spring">
+    <!-- create two routes from the template -->
+    <templatedRoute routeTemplateRef="myXmlTemplate">
+        <parameter name="name" value="one"/>
+        <parameter name="greeting" value="Hello"/>
+    </templatedRoute>
+    <templatedRoute routeTemplateRef="myXmlTemplate">
+        <parameter name="name" value="deux"/>
+        <parameter name="greeting" value="Bonjour"/>
+        <parameter name="myPeriod" value="5s"/>
+    </templatedRoute>
+</templatedRoutes>

--- a/routetemplate-xml/src/main/resources/templates/my-template.xml
+++ b/routetemplate-xml/src/main/resources/templates/my-template.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<routeTemplates xmlns="http://camel.apache.org/schema/spring">
+
+    <routeTemplate id="myXmlTemplate">
+        <templateParameter name="name"/>
+        <templateParameter name="greeting"/>
+        <templateParameter name="myPeriod" defaultValue="3s"/>
+        <route>
+            <from uri="timer:{{name}}?period={{myPeriod}}"/>
+            <setBody>
+                <simple>{{greeting}} {{name}}</simple>
+            </setBody>
+            <log message="XML says ${body}"/>
+        </route>
+    </routeTemplate>
+
+</routeTemplates>

--- a/routetemplate-xml/src/test/java/sample/camel/MyCamelApplicationJUnit5Test.java
+++ b/routetemplate-xml/src/test/java/sample/camel/MyCamelApplicationJUnit5Test.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@CamelSpringBootTest
+@SpringBootTest(classes = MyCamelApplication.class)
+class MyCamelApplicationJUnit5Test {
+
+    @Autowired
+    private CamelContext camelContext;
+
+    @Test
+    void shouldProduceMessages() throws Exception {
+        // we expect that one or more messages is automatic done by the Camel
+        // route as it uses a timer to trigger
+        NotifyBuilder notify = new NotifyBuilder(camelContext).whenDone(1).create();
+
+        assertTrue(notify.matches(10, TimeUnit.SECONDS));
+    }
+
+}


### PR DESCRIPTION
I've added upstream examples that were not present downstream and use supported/productized transitive dependencies.

[Add Artemis Example](https://github.com/jboss-fuse/camel-spring-boot-examples/commit/2c20bb274a081436615f2f70c6b7de351f8aa3cc)

[Add Azure Example](https://github.com/jboss-fuse/camel-spring-boot-examples/commit/198e16e7b9ed2db05b4b54312b2547bcfb7f7d0d)

[Add EndpointDSL Example](https://github.com/jboss-fuse/camel-spring-boot-examples/commit/7254ab3e8df57d0d56b80b13215003d1adb1ba28)

[Add OpenAPI First Example - DOES NOT COMPILE WITH CAMEL 4.4](https://github.com/jboss-fuse/camel-spring-boot-examples/commit/4fca53af41bf2b6518ac2c886ac8a8fe08575d7a)

[Add Platform HTTP Example](https://github.com/jboss-fuse/camel-spring-boot-examples/commit/23106354efff4e5227df6dfdc5f70e9354dd7c52)

[Add Routes Configuration Example](https://github.com/jboss-fuse/camel-spring-boot-examples/commit/8ce29205c0623946bee0b3857c874bf5f6c4770d)

[Add Routetemplate XML Example](https://github.com/jboss-fuse/camel-spring-boot-examples/commit/35cc56b29194c703c7a5a1457b322940b1f7320e)

At the moment, one example does not build due to camel-spring-boot version 4.4, once the version will be updated, all the examples will compile.