### PR TITLE
[CSB-5422] - Filesystem RWX mode not supported by gp3-csi storage class on AWS

### DIFF
--- a/spring-boot-jta-jpa-autoconfigure/src/main/jkube/pvc.yml
+++ b/spring-boot-jta-jpa-autoconfigure/src/main/jkube/pvc.yml
@@ -4,7 +4,7 @@ metadata:
   name: @project.artifactId@
 spec:
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
You don't need to use RWX access mode. That would make the "JTA-JPA Autoconfiguration" OCP on AWS-compatible