### PR TITLE
CSB-4993: Refactor examples, this way each example is an atomic project

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ readme's instructions.
 === Examples
 
 // examples: START
-Number of Examples: 63 (0 deprecated)
+Number of Examples: 64 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===
@@ -131,6 +131,8 @@ Number of Examples: 63 (0 deprecated)
 
 | link:activemq/README.adoc[Activemq] (activemq) | Messaging | An example showing how to work with Camel, ActiveMQ openwire and Spring Boot
 
+| link:amq-cert-manager/README.adoc[Amq Cert Manager] (amq-cert-manager) | Messaging | An example showing how to work with Camel, ActiveMQ Amqp and Spring Boot
+
 | link:amqp/README.adoc[Amqp] (amqp) | Messaging | An example showing how to work with Camel, ActiveMQ Amqp and Spring Boot
 
 | link:amqp-salesforce/README.adoc[Amqp Salesforce] (amqp-salesforce) | Messaging | AMQP message sending is created as contacts in Salesforce
@@ -139,7 +141,7 @@ Number of Examples: 63 (0 deprecated)
 
 | link:kafka-avro/README.adoc[Kafka Avro] (kafka-avro) | Messaging | An example for Kafka avro
 
-| link:kafka-oauth-ocp/README.adoc[Kafka OAuth on OCP] (kafka-oauth-ocp) | Messaging | An example for Kafka on OCP using integrated OAuth
+| link:kafka-oauth-ocp/README.adoc[Kafka Oauth Ocp] (kafka-oauth-ocp) | Messaging | An example for Kafka on OCP using integrated OAuth
 
 | link:kafka-offsetrepository/README.adoc[Kafka Offsetrepository] (kafka-offsetrepository) | Messaging | An example for Kafka offsetrepository
 

--- a/activemq/pom.xml
+++ b/activemq/pom.xml
@@ -33,7 +33,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <activemq-version>5.18.3</activemq-version>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/activemq/pom.xml
+++ b/activemq/pom.xml
@@ -20,23 +20,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-      <groupId>org.apache.camel.springboot.example</groupId>
-      <artifactId>examples</artifactId>
-      <version>4.10.3-SNAPSHOT</version>
-    </parent>
     
     <artifactId>camel-example-spring-boot-activemq</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>
     <name>Camel SB Examples :: ActiveMQ</name>
     <description>An example showing how to work with Camel, ActiveMQ openwire and Spring Boot</description>
     
     <properties>
         <category>Messaging</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <activemq-version>5.18.3</activemq-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/actuator-http-metrics/pom.xml
+++ b/actuator-http-metrics/pom.xml
@@ -31,7 +31,7 @@
         <category>Management and Monitoring</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/actuator-http-metrics/pom.xml
+++ b/actuator-http-metrics/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-actuator-http-metrics</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Actuator HTTP Metrics</name>
     <description>Example on how to use Spring Boot's Actuator endpoints to gather info like mappings or metrics</description>
 
@@ -35,7 +31,8 @@
         <category>Management and Monitoring</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/amq-cert-manager/pom.xml
+++ b/amq-cert-manager/pom.xml
@@ -33,7 +33,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/amq-cert-manager/pom.xml
+++ b/amq-cert-manager/pom.xml
@@ -123,7 +123,9 @@
         <profile>
             <id>openshift</id>
             <properties>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
                 <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <build>
                 <defaultGoal>install</defaultGoal>

--- a/amq-cert-manager/pom.xml
+++ b/amq-cert-manager/pom.xml
@@ -22,13 +22,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-amq-cert-manager</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: AMQ using cert-manager operator</name>
     <description>An example showing how to work with Camel, ActiveMQ Amqp and Spring Boot</description>
 
@@ -37,6 +33,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/amqp-salesforce/pom.xml
+++ b/amqp-salesforce/pom.xml
@@ -37,7 +37,7 @@
         <camelSalesforce.namespace></camelSalesforce.namespace>
         <camelSalesforce.sslContextParameters.secureSocketProtocol>TLSv1.3</camelSalesforce.sslContextParameters.secureSocketProtocol>
         <camelSalesforce.loginUrl>https://login.salesforce.com</camelSalesforce.loginUrl>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/amqp-salesforce/pom.xml
+++ b/amqp-salesforce/pom.xml
@@ -21,14 +21,10 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-amqp-salesforce</artifactId>
     <packaging>jar</packaging>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: AMQP Salesforce</name>
     <description>AMQP message sending is created as contacts in Salesforce</description>
 
@@ -41,6 +37,8 @@
         <camelSalesforce.namespace></camelSalesforce.namespace>
         <camelSalesforce.sslContextParameters.secureSocketProtocol>TLSv1.3</camelSalesforce.sslContextParameters.secureSocketProtocol>
         <camelSalesforce.loginUrl>https://login.salesforce.com</camelSalesforce.loginUrl>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/amqp-salesforce/pom.xml
+++ b/amqp-salesforce/pom.xml
@@ -233,6 +233,9 @@
             </activation>
             <properties>
                 <spring.profiles.active>openshift</spring.profiles.active>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <dependencies>
             </dependencies>

--- a/amqp/pom.xml
+++ b/amqp/pom.xml
@@ -33,7 +33,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/amqp/pom.xml
+++ b/amqp/pom.xml
@@ -22,13 +22,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-amqp</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Amqp</name>
     <description>An example showing how to work with Camel, ActiveMQ Amqp and Spring Boot</description>
 
@@ -37,7 +33,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/amqp/pom.xml
+++ b/amqp/pom.xml
@@ -142,6 +142,9 @@
             </activation>
             <properties>
                 <spring.profiles.active>openshift</spring.profiles.active>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <dependencies>
             </dependencies>

--- a/arangodb/pom.xml
+++ b/arangodb/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <category>Database</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/arangodb/pom.xml
+++ b/arangodb/pom.xml
@@ -19,19 +19,17 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
 
     <artifactId>camel-example-spring-boot-arangodb</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: ArangoDB</name>
     <description>An example showing the Camel ArangoDb component with Spring Boot</description>
 
     <properties>
         <category>Database</category>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <!-- Spring-Boot and Camel BOM -->
@@ -89,7 +87,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot-version}</version>
+                <version>${spring-boot-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/artemis/pom.xml
+++ b/artemis/pom.xml
@@ -141,7 +141,9 @@
             <id>openshift</id>
             <properties>
                 <spring.profiles.active>openshift</spring.profiles.active>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
                 <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <build>
                 <finalName>${project.artifactId}</finalName>

--- a/artemis/pom.xml
+++ b/artemis/pom.xml
@@ -32,7 +32,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/artemis/pom.xml
+++ b/artemis/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-artemis</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: artemis</name>
     <description>An example showing how to work with Camel, ActiveMQ Artemis and Spring Boot</description>
 
@@ -36,6 +32,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/aws2-s3/pom.xml
+++ b/aws2-s3/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <category>Cloud</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/aws2-s3/pom.xml
+++ b/aws2-s3/pom.xml
@@ -19,19 +19,17 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
 
     <artifactId>camel-example-spring-boot-aws2-s3</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: AWS2 S3</name>
     <description>An example showing the Camel AWS2 S3 component with Spring Boot</description>
 
     <properties>
         <category>Cloud</category>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <!-- Spring-Boot and Camel BOM -->
@@ -88,7 +86,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot-version}</version>
+                <version>${spring-boot-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -22,13 +22,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.apache.camel.springboot.example</groupId>
-    <artifactId>examples</artifactId>
-    <version>4.10.3-SNAPSHOT</version>
-  </parent>
-
+  <groupId>org.apache.camel.springboot.example</groupId>
   <artifactId>camel-example-spring-boot-azure</artifactId>
+  <version>4.10.3-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Camel SB Examples :: Azure</name>
   <description>An example showing the Camel Azure component with Spring Boot</description>

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -38,6 +38,8 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+    <spring-boot-version>3.4.4</spring-boot-version>
   </properties>
 
   <!-- Spring-Boot and Camel BOM -->

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+    <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
     <spring-boot-version>3.4.4</spring-boot-version>
   </properties>
 

--- a/endpointdsl/pom.xml
+++ b/endpointdsl/pom.xml
@@ -32,7 +32,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/endpointdsl/pom.xml
+++ b/endpointdsl/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-endpointdsl</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Endpoint DSL</name>
     <description>Using type-safe Endpoint DSL</description>
 
@@ -36,6 +32,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/fhir-auth-tx/pom.xml
+++ b/fhir-auth-tx/pom.xml
@@ -33,9 +33,9 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
-        <hapi-version>2.6.0</hapi-version>
+        <hapi-version>2.6.0.redhat-00001</hapi-version>
     </properties>
 
     <dependencyManagement>

--- a/fhir-auth-tx/pom.xml
+++ b/fhir-auth-tx/pom.xml
@@ -22,12 +22,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
+		<groupId>org.apache.camel.springboot</groupId>
+		<artifactId>spring-boot</artifactId>
+		<version>4.10.3.redhat-00003</version>
+	</parent>
 
     <artifactId>camel-example-spring-boot-fhir-auth-tx</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: FHIR :: Transaction</name>
     <description>An example showing how to work with Camel, FHIR Authorization, FHIR Transaction and Spring Boot
     </description>
@@ -37,7 +39,9 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+        <!--<hapi-version>-->
     </properties>
 
     <dependencyManagement>

--- a/fhir-auth-tx/pom.xml
+++ b/fhir-auth-tx/pom.xml
@@ -21,12 +21,6 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-		<groupId>org.apache.camel.springboot</groupId>
-		<artifactId>spring-boot</artifactId>
-		<version>4.10.3.redhat-00003</version>
-	</parent>
-
     <artifactId>camel-example-spring-boot-fhir-auth-tx</artifactId>
     <groupId>org.apache.camel.springboot.example</groupId>
     <version>4.10.3-SNAPSHOT</version>    
@@ -41,7 +35,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
-        <!--<hapi-version>-->
+        <hapi-version>2.6.0</hapi-version>
     </properties>
 
     <dependencyManagement>

--- a/fhir/pom.xml
+++ b/fhir/pom.xml
@@ -22,12 +22,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
+		<groupId>org.apache.camel.springboot</groupId>
+		<artifactId>spring-boot</artifactId>
+		<version>4.10.3.redhat-00003</version>
+	</parent>
 
     <artifactId>camel-example-spring-boot-fhir</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: FHIR</name>
     <description>An example showing how to work with Camel, FHIR and Spring Boot</description>
 
@@ -36,7 +38,10 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+        <!--hapi-version>${hapi-version}</hapi-version>
+        <camel-community-version>${camel-community-version}</camel-community-version-->
     </properties>
 
     <dependencyManagement>

--- a/fhir/pom.xml
+++ b/fhir/pom.xml
@@ -32,9 +32,9 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
-        <hapi-version>2.6.0</hapi-version>
+        <hapi-version>2.6.0.redhat-00001</hapi-version>
         <camel-community-version>4.10.3</camel-community-version>
     </properties>
 

--- a/fhir/pom.xml
+++ b/fhir/pom.xml
@@ -21,12 +21,6 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-		<groupId>org.apache.camel.springboot</groupId>
-		<artifactId>spring-boot</artifactId>
-		<version>4.10.3.redhat-00003</version>
-	</parent>
-
     <artifactId>camel-example-spring-boot-fhir</artifactId>
     <groupId>org.apache.camel.springboot.example</groupId>
     <version>4.10.3-SNAPSHOT</version>    
@@ -40,8 +34,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
-        <!--hapi-version>${hapi-version}</hapi-version>
-        <camel-community-version>${camel-community-version}</camel-community-version-->
+        <hapi-version>2.6.0</hapi-version>
+        <camel-community-version>4.10.3</camel-community-version>
     </properties>
 
     <dependencyManagement>

--- a/health-checks/pom.xml
+++ b/health-checks/pom.xml
@@ -30,7 +30,7 @@
         <category>Health Care</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/health-checks/pom.xml
+++ b/health-checks/pom.xml
@@ -21,20 +21,17 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-health-checks</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Health Checks</name>
     <description>An example on how to work with health checks ib a simple Apache Camel application using Spring Boot.</description>
     <properties>
         <category>Health Care</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/http-ssl/ocp-ssl-camel-server/pom.xml
+++ b/http-ssl/ocp-ssl-camel-server/pom.xml
@@ -84,6 +84,8 @@
 				<jkube.enricher.jkube-controller.type>Deployment</jkube.enricher.jkube-controller.type>
 				<jkube.enricher.jkube-openshift-route.tlsTermination>passthrough</jkube.enricher.jkube-openshift-route.tlsTermination>
 				<jkube.enricher.jkube-openshift-route.tlsInsecureEdgeTerminationPolicy>Redirect</jkube.enricher.jkube-openshift-route.tlsInsecureEdgeTerminationPolicy>
+				<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+				<jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
 			</properties>
 			<build>
 				<plugins>

--- a/http-ssl/ocp-ssl-client/pom.xml
+++ b/http-ssl/ocp-ssl-client/pom.xml
@@ -122,7 +122,9 @@
 				<sbProfile>openshift</sbProfile>
 				<jkube.enricher.jkube-service.name>ocp-ssl-client</jkube.enricher.jkube-service.name>
 				<jkube.enricher.jkube-controller.name>ocp-ssl-client</jkube.enricher.jkube-controller.name>
-				<jkube.enricher.jkube-controller.type>Deployment</jkube.enricher.jkube-controller.type>
+				<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
 			</properties>
 			<build>
 				<plugins>

--- a/http-ssl/pom.xml
+++ b/http-ssl/pom.xml
@@ -29,7 +29,7 @@
 
 	<properties>
 		<category>Rest</category>
-		<camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+		<camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
 	</properties>
 

--- a/http-ssl/pom.xml
+++ b/http-ssl/pom.xml
@@ -20,19 +20,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.apache.camel.springboot.example</groupId>
-		<artifactId>examples</artifactId>
-		<version>4.10.3-SNAPSHOT</version>
-	</parent>
-
+	<groupId>org.apache.camel.springboot.example</groupId>
 	<artifactId>camel-example-spring-boot-http-ssl</artifactId>
 	<name>Camel SB Examples :: HTTP SSL</name>
+	<version>4.10.3-SNAPSHOT</version>
 	<description>An example showing the Camel HTTP component with Spring Boot and SSL</description>
 	<packaging>pom</packaging>
 
 	<properties>
 		<category>Rest</category>
+		<camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
 	</properties>
 
 	<dependencyManagement>

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -20,19 +20,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-infinispan</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Infinispan</name>
     <description>An example showing the Camel Infinispan component with Spring Boot</description>
 
     <properties>
         <category>Cloud</category>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+        <testcontainers-version>1.20.6</testcontainers-version>
     </properties>
 
     <!-- Spring-Boot and Camel BOM -->
@@ -101,12 +99,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
+        <!--dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-junit5</artifactId>
             <version>${camel-version}</version>
             <scope>test</scope>
-        </dependency>
+        </dependency-->
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
@@ -119,7 +117,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot-version}</version>
+                <version>${spring-boot-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <category>Cloud</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
         <testcontainers-version>1.20.6</testcontainers-version>
     </properties>
@@ -99,12 +99,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
-            <version>${camel-version}</version>
-            <scope>test</scope>
-        </dependency-->
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>

--- a/jira/pom.xml
+++ b/jira/pom.xml
@@ -21,12 +21,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
+		<groupId>org.apache.camel.springboot</groupId>
+		<artifactId>spring-boot</artifactId>
+		<version>4.10.3.redhat-00003</version>
+	</parent>
 
     <artifactId>camel-example-spring-boot-jira</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Jira</name>
     <description>An example that uses Jira Camel API</description>
     <packaging>jar</packaging>
@@ -34,6 +36,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <category>Beginner</category>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+        <!--guava-version></guava-version>
+        <exec-maven-plugin-version></exec-maven-plugin-version-->
     </properties>
 
     <dependencyManagement>

--- a/jira/pom.xml
+++ b/jira/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <category>Beginner</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
         <guava-version>33.4.7-jre</guava-version>
         <exec-maven-plugin-version>3.5.0</exec-maven-plugin-version>

--- a/jira/pom.xml
+++ b/jira/pom.xml
@@ -20,12 +20,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-		<groupId>org.apache.camel.springboot</groupId>
-		<artifactId>spring-boot</artifactId>
-		<version>4.10.3.redhat-00003</version>
-	</parent>
-
     <artifactId>camel-example-spring-boot-jira</artifactId>
     <groupId>org.apache.camel.springboot.example</groupId>
     <version>4.10.3-SNAPSHOT</version>    
@@ -38,8 +32,8 @@
         <category>Beginner</category>
         <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
-        <!--guava-version></guava-version>
-        <exec-maven-plugin-version></exec-maven-plugin-version-->
+        <guava-version>33.4.7-jre</guava-version>
+        <exec-maven-plugin-version>3.5.0</exec-maven-plugin-version>
     </properties>
 
     <dependencyManagement>

--- a/jolokia/pom.xml
+++ b/jolokia/pom.xml
@@ -21,13 +21,9 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <artifactId>examples</artifactId>
-    <groupId>org.apache.camel.springboot.example</groupId>
-    <version>4.10.3-SNAPSHOT</version>
-  </parent>
-
   <artifactId>camel-example-spring-boot-jolokia</artifactId>
+  <groupId>org.apache.camel.springboot.example</groupId>
+  <version>4.10.3-SNAPSHOT</version>
   <name>Camel SB Examples :: Jolokia</name>
   <description>An example that uses Jolokia to monitor and to manage Camel Routes</description>
   <packaging>jar</packaging>
@@ -35,6 +31,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <category>Management and Monitoring</category>
+    <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+    <spring-boot-version>3.4.4</spring-boot-version>
   </properties>
 
   <dependencyManagement>

--- a/jolokia/pom.xml
+++ b/jolokia/pom.xml
@@ -17,7 +17,9 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -78,10 +80,10 @@
       <groupId>org.apache.camel.springboot</groupId>
       <artifactId>camel-stream-starter</artifactId>
     </dependency>
-	<dependency>
+    <dependency>
       <groupId>org.apache.camel.springboot</groupId>
       <artifactId>camel-jolokia-starter</artifactId>
-	</dependency>
+    </dependency>
 
   </dependencies>
 
@@ -105,6 +107,11 @@
   <profiles>
     <profile>
       <id>openshift</id>
+      <properties>
+        <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+        <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+        <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
+      </properties>
       <build>
         <defaultGoal>install</defaultGoal>
         <plugins>

--- a/jolokia/pom.xml
+++ b/jolokia/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <category>Management and Monitoring</category>
-    <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+    <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
     <spring-boot-version>3.4.4</spring-boot-version>
   </properties>
 

--- a/kafka-avro/pom.xml
+++ b/kafka-avro/pom.xml
@@ -160,6 +160,9 @@
             </activation>
             <properties>
                 <spring.profiles.active>openshift</spring.profiles.active>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <dependencies>
             </dependencies>

--- a/kafka-avro/pom.xml
+++ b/kafka-avro/pom.xml
@@ -20,12 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
 
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>
   <artifactId>camel-example-spring-boot-kafka-avro</artifactId>
   <name>Camel SB Examples :: Kafka :: Avro</name>
   <description>An example for Kafka avro</description>
@@ -34,7 +31,8 @@
         <category>Messaging</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
         <avro.maven.plugin-version>1.11.2</avro.maven.plugin-version>
         <apicurio-version>2.4.3.Final</apicurio-version>
         <javafaker-version>1.0.2</javafaker-version>
@@ -131,7 +129,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot-version}</version>
+                <version>${spring-boot-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/kafka-avro/pom.xml
+++ b/kafka-avro/pom.xml
@@ -31,10 +31,10 @@
         <category>Messaging</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
-        <avro.maven.plugin-version>1.11.2</avro.maven.plugin-version>
-        <apicurio-version>2.4.3.Final</apicurio-version>
+        <avro.maven.plugin-version>1.12.0.redhat-00001</avro.maven.plugin-version>
+        <apicurio-version>3.0.0.redhat-00001</apicurio-version>
         <javafaker-version>1.0.2</javafaker-version>
     </properties>
 

--- a/kafka-oauth-ocp/pom.xml
+++ b/kafka-oauth-ocp/pom.xml
@@ -20,13 +20,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
 
+  <groupId>org.apache.camel.springboot.example</groupId>
   <artifactId>camel-example-spring-boot-kafka-oauth-ocp</artifactId>
+  <version>4.10.3-SNAPSHOT</version>
   <name>Camel SB Examples :: Kafka :: OAuth on OCP</name>
   <description>An example for Kafka on OCP using integrated OAuth</description>
 
@@ -34,7 +31,8 @@
         <category>Messaging</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>
@@ -122,7 +120,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring.boot-version}</version>
+        <version>${spring-boot-version}</version>
         <executions>
           <execution>
             <goals>

--- a/kafka-oauth-ocp/pom.xml
+++ b/kafka-oauth-ocp/pom.xml
@@ -136,7 +136,9 @@
     <profile>
       <id>openshift</id>
       <properties>
+        <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
         <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+        <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
       </properties>
       <build>
         <defaultGoal>install</defaultGoal>

--- a/kafka-oauth-ocp/pom.xml
+++ b/kafka-oauth-ocp/pom.xml
@@ -31,7 +31,7 @@
         <category>Messaging</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/kafka-offsetrepository/pom.xml
+++ b/kafka-offsetrepository/pom.xml
@@ -22,13 +22,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-kafka-offsetrepository</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Kafka :: offsetrepository</name>
     <description>An example for Kafka offsetrepository</description>
 
@@ -36,7 +32,8 @@
         <category>Messaging</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/kafka-offsetrepository/pom.xml
+++ b/kafka-offsetrepository/pom.xml
@@ -125,6 +125,9 @@
             </activation>
             <properties>
                 <spring.profiles.active>openshift</spring.profiles.active>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <dependencies>
             </dependencies>

--- a/kafka-offsetrepository/pom.xml
+++ b/kafka-offsetrepository/pom.xml
@@ -32,7 +32,7 @@
         <category>Messaging</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -32,7 +32,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-kamelet-chucknorris</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Spring Boot :: Kamelet Chuck Norris</name>
     <description>How easy it is to create your own Kamelets</description>
 
@@ -36,7 +32,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/load-balancer-eip/pom.xml
+++ b/load-balancer-eip/pom.xml
@@ -15,7 +15,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/load-balancer-eip/pom.xml
+++ b/load-balancer-eip/pom.xml
@@ -2,14 +2,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>examples</artifactId>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-example-spring-boot-load-balancer-eip</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Custom Type Converter</name>
     <description>An example showing Load Balancer EIP with Camel and Spring Boot</description>
 
@@ -18,7 +15,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/mail-ms-exchange-oauth2/pom.xml
+++ b/mail-ms-exchange-oauth2/pom.xml
@@ -2,17 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>examples</artifactId>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-example-spring-boot-mail-exchange-oauth2</artifactId>
     <packaging>jar</packaging>
 
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Mail :: Microsoft Exchange Oauth2 Authentication</name>
     <description>An example showing how to use Camel on Spring Boot to connect
         with IMAP protocol and access email data for Office 365 users using OAuth2 authentication</description>
@@ -21,6 +17,8 @@
         <msal4j-version>1.13.2</msal4j-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <category>Mail</category>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>
@@ -29,13 +27,6 @@
                 <groupId>com.redhat.camel.springboot.platform</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
                 <version>${camel-spring-boot-version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel</groupId>
-                <artifactId>camel-bom</artifactId>
-                <version>${camel-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -68,8 +59,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-mail-microsoft-oauth</artifactId>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-mail-microsoft-oauth-starter</artifactId>
         </dependency>
 
         <!-- monitoring -->

--- a/mail-ms-exchange-oauth2/pom.xml
+++ b/mail-ms-exchange-oauth2/pom.xml
@@ -17,7 +17,7 @@
         <msal4j-version>1.13.2</msal4j-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <category>Mail</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -33,7 +33,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-master</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Master</name>
     <description>An example showing how to work with Camel's Master component and Spring Boot</description>
     <packaging>jar</packaging>
@@ -37,7 +33,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -130,6 +130,9 @@
             <id>openshift</id>
             <properties>
                 <sbProfile>openshift</sbProfile>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <activation>
                 <property>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -30,9 +30,9 @@
     <properties>
         <category>Management and Monitoring</category>
 
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
-        <jolokia-version>2.0.1</jolokia-version>
+        <jolokia-version>2.2.8.redhat-00002</jolokia-version>
         <metrics-version>4.2.30</metrics-version>
     </properties>
 

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -21,12 +21,6 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-		<groupId>org.apache.camel.springboot</groupId>
-		<artifactId>spring-boot</artifactId>
-		<version>4.10.3.redhat-00003</version>
-	</parent>
-
     <artifactId>camel-example-spring-boot-metrics</artifactId>
     <groupId>org.apache.camel.springboot.example</groupId>
     <version>4.10.3-SNAPSHOT</version>    
@@ -39,7 +33,7 @@
         <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
         <jolokia-version>2.0.1</jolokia-version>
-        <!--metrics-version-->
+        <metrics-version>4.2.30</metrics-version>
     </properties>
 
     <dependencyManagement>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -22,20 +22,24 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
+		<groupId>org.apache.camel.springboot</groupId>
+		<artifactId>spring-boot</artifactId>
+		<version>4.10.3.redhat-00003</version>
+	</parent>
 
     <artifactId>camel-example-spring-boot-metrics</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Metrics</name>
     <description>An example showing how to work with Camel and Spring Boot and report metrics to Graphite</description>
 
     <properties>
         <category>Management and Monitoring</category>
 
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
         <jolokia-version>2.0.1</jolokia-version>
+        <!--metrics-version-->
     </properties>
 
     <dependencyManagement>

--- a/monitoring-micrometrics-grafana-prometheus/pom.xml
+++ b/monitoring-micrometrics-grafana-prometheus/pom.xml
@@ -19,10 +19,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8
         </project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
-        <jolokia-version>2.0.1</jolokia-version>
-        <prometheus-version>1.0.1</prometheus-version>
+        <jolokia-version>2.2.8.redhat-00002</jolokia-version>
+        <prometheus-version>1.2.0.redhat-00001</prometheus-version>
         <docker.containerNamePattern>%a</docker.containerNamePattern>
         <jkube.replicas>3</jkube.replicas>
         <jkube.namespace>csb-monitoring</jkube.namespace>

--- a/monitoring-micrometrics-grafana-prometheus/pom.xml
+++ b/monitoring-micrometrics-grafana-prometheus/pom.xml
@@ -275,6 +275,11 @@
 
         <profile>
             <id>openshift</id>
+            <properties>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/monitoring-micrometrics-grafana-prometheus/pom.xml
+++ b/monitoring-micrometrics-grafana-prometheus/pom.xml
@@ -3,18 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
 
     <artifactId>camel-example-spring-boot-monitoring</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Monitoring</name>
     <description>Example on how to use Spring Boot's Actuator endpoints to
         gather info like mappings or metrics
     </description>
-
 
     <properties>
         <category>Management and Monitoring</category>
@@ -23,7 +19,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8
         </project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
         <jolokia-version>2.0.1</jolokia-version>
         <prometheus-version>1.0.1</prometheus-version>
         <docker.containerNamePattern>%a</docker.containerNamePattern>

--- a/multi-datasource-2pc/pom.xml
+++ b/multi-datasource-2pc/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-muti-datasources-2pc</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Multiple pooled datasources with two-phase commit</name>
     <description>An example showing how to work with Camel and Spring Boot using multiple pooled datasources with two-phase commit</description>
 
@@ -36,6 +32,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/multi-datasource-2pc/pom.xml
+++ b/multi-datasource-2pc/pom.xml
@@ -32,7 +32,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/observation/client/pom.xml
+++ b/observation/client/pom.xml
@@ -125,6 +125,9 @@
             </activation>
             <properties>
                 <spring.profiles.active>openshift</spring.profiles.active>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <build>
                 <plugins>

--- a/observation/client/pom.xml
+++ b/observation/client/pom.xml
@@ -28,6 +28,8 @@
     </parent>
 
     <artifactId>camel-example-spring-boot-observation-client</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Observation :: Client</name>
     <description>An example showing how to trace incoming and outgoing messages from Camel with Micrometer Observation</description>
 

--- a/observation/loggingtracer/pom.xml
+++ b/observation/loggingtracer/pom.xml
@@ -28,6 +28,8 @@
     </parent>
 
     <artifactId>camel-example-spring-boot-observation-loggingtracer</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Observation :: LoggingTracer</name>
     <description>An example Observation Tracer</description>
 

--- a/observation/pom.xml
+++ b/observation/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <category>Management and Monitoring</category>
         <title>Micrometer Observation</title>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/observation/pom.xml
+++ b/observation/pom.xml
@@ -21,14 +21,10 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-observation</artifactId>
     <packaging>pom</packaging>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Observation</name>
     <description>An example showing how to trace incoming and outgoing messages from Camel with Micrometer Observation
     </description>
@@ -36,6 +32,8 @@
     <properties>
         <category>Management and Monitoring</category>
         <title>Micrometer Observation</title>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/observation/service1/pom.xml
+++ b/observation/service1/pom.xml
@@ -121,6 +121,9 @@
             </activation>
             <properties>
                 <spring.profiles.active>openshift</spring.profiles.active>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <build>
                 <plugins>

--- a/observation/service1/pom.xml
+++ b/observation/service1/pom.xml
@@ -28,6 +28,8 @@
     </parent>
 
     <artifactId>camel-example-spring-boot-observation-service1</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Observation :: Service 1</name>
     <description>An example showing how to trace incoming and outgoing messages from Camel with Micrometer Observation</description>
 

--- a/observation/service2/pom.xml
+++ b/observation/service2/pom.xml
@@ -28,6 +28,8 @@
     </parent>
 
     <artifactId>camel-example-spring-boot-observation-service2</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Observation :: Service 2</name>
     <description>An example showing how to trace incoming and outgoing messages from Camel with Micrometer Observation</description>
 

--- a/observation/service2/pom.xml
+++ b/observation/service2/pom.xml
@@ -122,6 +122,9 @@
             </activation>
             <properties>
                 <spring.profiles.active>openshift</spring.profiles.active>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <build>
                 <plugins>

--- a/openapi-contract-first/pom.xml
+++ b/openapi-contract-first/pom.xml
@@ -32,7 +32,7 @@
         <category>Rest</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/openapi-contract-first/pom.xml
+++ b/openapi-contract-first/pom.xml
@@ -22,13 +22,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-openapi-contract-first</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: OpenAPI Contract First</name>
     <description>Contract First OpenAPI example</description>
 
@@ -36,6 +32,8 @@
         <category>Rest</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/opentelemetry/car-booking/pom.xml
+++ b/opentelemetry/car-booking/pom.xml
@@ -28,6 +28,8 @@
     </parent>
 
     <artifactId>camel-example-spring-boot-opentelemetry-carbooking</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: OpenTelemetry :: CarBooking</name>
     <description>An example showing how to use Camel with OpenTelemetry</description>
 

--- a/opentelemetry/car-booking/pom.xml
+++ b/opentelemetry/car-booking/pom.xml
@@ -217,6 +217,9 @@
             </activation>
             <properties>
                 <sbProfile>openshift</sbProfile>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <build>
                 <plugins>

--- a/opentelemetry/flight-booking/pom.xml
+++ b/opentelemetry/flight-booking/pom.xml
@@ -206,6 +206,9 @@
 			</activation>
 			<properties>
 				<sbProfile>openshift</sbProfile>
+				<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
 			</properties>
 			<build>
 				<plugins>

--- a/opentelemetry/hotel-booking/pom.xml
+++ b/opentelemetry/hotel-booking/pom.xml
@@ -210,6 +210,9 @@
 			</activation>
 			<properties>
 				<sbProfile>openshift</sbProfile>
+				<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
 			</properties>
 			<build>
 				<plugins>

--- a/opentelemetry/pom.xml
+++ b/opentelemetry/pom.xml
@@ -21,14 +21,10 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-opentelemetry</artifactId>
     <packaging>pom</packaging>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: OpenTelemetry</name>
     <description>An example showing how to use Camel with OpenTelemetry
     </description>
@@ -36,6 +32,8 @@
     <properties>
         <category>Management and Monitoring</category>
         <title>OpenTelemetry</title>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <modules>

--- a/opentelemetry/pom.xml
+++ b/opentelemetry/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <category>Management and Monitoring</category>
         <title>OpenTelemetry</title>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/opentelemetry/trip-booking/pom.xml
+++ b/opentelemetry/trip-booking/pom.xml
@@ -204,6 +204,9 @@
 			</activation>
 			<properties>
 				<sbProfile>openshift</sbProfile>
+				<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
 			</properties>
 			<build>
 				<plugins>

--- a/paho-mqtt5-shared-subscriptions/pom.xml
+++ b/paho-mqtt5-shared-subscriptions/pom.xml
@@ -2,22 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>examples</artifactId>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-example-spring-boot-paho-mqtt5-shared-subscriptions</artifactId>
     <packaging>jar</packaging>
-
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Paho MQTT5 Shared Subscriptions</name>
     <description>An example showing  how to set up multiple mqtt5 consumers that use shared subscription feature of MQTT5</description>
 
     <properties>
         <category>Messaging</category>
         <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/paho-mqtt5-shared-subscriptions/pom.xml
+++ b/paho-mqtt5-shared-subscriptions/pom.xml
@@ -117,6 +117,9 @@
             </activation>
             <properties>
                 <spring.profiles.active>openshift</spring.profiles.active>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <dependencies>
             </dependencies>

--- a/paho-mqtt5-shared-subscriptions/pom.xml
+++ b/paho-mqtt5-shared-subscriptions/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <category>Messaging</category>
         <spring.boot-version>${spring-boot-version}</spring.boot-version>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/platform-http/pom.xml
+++ b/platform-http/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <category>Rest</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/platform-http/pom.xml
+++ b/platform-http/pom.xml
@@ -19,18 +19,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-platform-http</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: REST DSL and Platform HTTP</name>
     <description>An example showing Camel REST DSL with platform HTTP</description>
 
     <properties>
         <category>Rest</category>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <!-- Spring-Boot and Camel BOM -->
@@ -85,8 +83,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
-            <version>${camel-version}</version>
+            <artifactId>camel-test-spring-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pojo/pom.xml
+++ b/pojo/pom.xml
@@ -22,13 +22,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-pojo</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: POJO Routing</name>
     <description>An example showing how to work with Camel POJO routing with Spring Boot</description>
 
@@ -37,7 +33,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>
@@ -103,10 +100,8 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
-            <version>${camel-version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/pojo/pom.xml
+++ b/pojo/pom.xml
@@ -33,7 +33,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,25 +101,6 @@
 		<module>xml-import</module>
 	</modules>
 
-	<properties>
-		<camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
-		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-		<skip.starting.camel.context>false</skip.starting.camel.context>
-		<javax.servlet.api.version>4.0.1</javax.servlet.api.version>
-		<jkube-maven-plugin-version>1.18.1.redhat-00002</jkube-maven-plugin-version>
-		<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:1.21</jkube.generator.from>
-		<jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
-		<kafka-avro-serializer-version>5.2.2</kafka-avro-serializer-version>
-		<reactor-version>3.2.22.RELEASE</reactor-version>
-		<testcontainers-version>1.19.8</testcontainers-version>
-		<hapi-structures-v24-version>2.3</hapi-structures-v24-version>
-		<lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
-		<docker-maven-plugin.version>0.45.1</docker-maven-plugin.version>
-		<testcontainers-keycloak.version>3.6.0</testcontainers-keycloak.version>
-		<json-unit-assertj.version>4.1.0</json-unit-assertj.version>
-		<lombok.version>1.18.36</lombok.version>
-	</properties>
-
 	<repositories>
 		<repository>
 			<id>apache.snapshots</id>
@@ -145,29 +126,6 @@
 			</releases>
 		</pluginRepository>
 	</pluginRepositories>
-
-	<dependencyManagement>
-		<dependencies>
-			<!--
-			  CAMEL-13084 Fix the spring-boot examples start up error by overriding servlet API version from camel-parent
-			  We need to clean it up once camel-parent upgrade the servlet api version.
-			-->
-			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>javax.servlet-api</artifactId>
-				<version>${javax.servlet.api.version}</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.camel.springboot</groupId>
-			<artifactId>spring-boot</artifactId>
-			<version>${camel-spring-boot-version}</version>
-			<type>pom</type>
-		</dependency>
-	</dependencies>
 
 	<build>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot</groupId>
 		<artifactId>spring-boot</artifactId>
-		<version>4.10.3.redhat-00003</version>
+		<version>4.10.3.redhat-00004</version>
 	</parent>
 
 	<groupId>org.apache.camel.springboot.example</groupId>
@@ -179,6 +179,126 @@
 					</systemPropertyVariables>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+        		<artifactId>exec-maven-plugin</artifactId>
+        		<version>3.5.0</version>
+				<executions>
+					<execution>
+						<id>update-properties</id>
+						<phase>pre-clean</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>mvn</executable>
+							<arguments>
+								<argument>versions:update-property</argument>
+								<argument>-Dproperty=hapi-version,guava-version,exec-maven-plugin-version,jolokia-version,metrics-version,lombok-mapstruct-binding.version,mapstruct-version,activemq-version,testcontainers-version,javafaker-version,apicurio-version,avro.maven.plugin-version,prometheus-version,reactor-version,build-helper-maven-plugin-version,maven-resources-plugin-version,awaitility-version</argument>
+								<argument>-DgenerateBackupPoms=false</argument>
+								<argument>-Dmaven.version.ignore=(?i).*-(alpha|beta|m|rc)([-.]?\d+)?</argument>
+							</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<id>update-camel</id>
+						<phase>pre-clean</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>mvn</executable>
+							<arguments>
+								<argument>versions:set-property</argument>
+								<argument>-Dproperty=camel-version</argument>
+								<argument>-DnewVersion=${camel-version}</argument>
+								<argument>-DgenerateBackupPoms=false</argument>
+							</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<id>update-camel-spring-boot</id>
+						<phase>pre-clean</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>mvn</executable>
+							<arguments>
+								<argument>versions:set-property</argument>
+								<argument>-Dproperty=camel-spring-boot-version</argument>
+								<argument>-DnewVersion=${project.parent.version}</argument>
+								<argument>-DgenerateBackupPoms=false</argument>
+							</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<id>update-spring-boot</id>
+						<phase>pre-clean</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>mvn</executable>
+							<arguments>
+								<argument>versions:set-property</argument>
+								<argument>-Dproperty=spring-boot-version</argument>
+								<argument>-DnewVersion=${spring-boot-version}</argument>
+								<argument>-DgenerateBackupPoms=false</argument>
+							</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<id>update-cxf</id>
+						<phase>pre-clean</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>mvn</executable>
+							<arguments>
+								<argument>versions:set-property</argument>
+								<argument>-Dproperty=cxf-version</argument>
+								<argument>-DnewVersion=${cxf-version}</argument>
+								<argument>-DgenerateBackupPoms=false</argument>
+							</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<id>update-camel-community</id>
+						<phase>pre-clean</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>mvn</executable>
+							<arguments>
+								<argument>versions:set-property</argument>
+								<argument>-Dproperty=camel-community-version</argument>
+								<argument>-DnewVersion=${camel-community-version}</argument>
+								<argument>-DgenerateBackupPoms=false</argument>
+							</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<id>update-jkube</id>
+						<phase>pre-clean</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>mvn</executable>
+							<arguments>
+								<argument>versions:set-property</argument>
+								<argument>-Dproperty=jkube-maven-plugin-version</argument>
+								<argument>-DnewVersion=${openshift-maven-plugin-version}</argument>
+								<argument>-DgenerateBackupPoms=false</argument>
+								<argument>-DprofileId=openshift</argument>
+							</arguments>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>
@@ -189,7 +309,6 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-
 	</build>
 
 	<profiles>

--- a/quartz/pom.xml
+++ b/quartz/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-quartz</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Quartz</name>
     <description>An example showing how to work with Camel Quartz and Camel Log with Spring Boot</description>
 
@@ -36,7 +32,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>
@@ -106,10 +103,8 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
-            <version>${camel-version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/quartz/pom.xml
+++ b/quartz/pom.xml
@@ -32,7 +32,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/rabbitmq/pom.xml
+++ b/rabbitmq/pom.xml
@@ -32,7 +32,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/rabbitmq/pom.xml
+++ b/rabbitmq/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-rabbitmq</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: RabbitMQ</name>
     <description>An example showing how to work with Camel and RabbitMQ</description>
 
@@ -36,7 +32,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>
@@ -111,10 +108,8 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
-            <version>${camel-version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/reactive-streams/pom.xml
+++ b/reactive-streams/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <category>Reactive</category>
 
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
         <reactor-version>3.7.4</reactor-version>
     </properties>

--- a/reactive-streams/pom.xml
+++ b/reactive-streams/pom.xml
@@ -21,14 +21,10 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-reactive-streams</artifactId>
     <packaging>jar</packaging>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Reactive Streams</name>
     <description>An example that shows how Camel can exchange data using reactive streams with Spring Boot reactor
     </description>
@@ -36,7 +32,9 @@
     <properties>
         <category>Reactive</category>
 
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+        <reactor-version>3.7.4</reactor-version>
     </properties>
 
     <dependencyManagement>
@@ -122,7 +120,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot-version}</version>
+                <version>${spring-boot-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/resilience4j/client/pom.xml
+++ b/resilience4j/client/pom.xml
@@ -28,6 +28,8 @@
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j-client</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Resilience4j :: Client</name>
     <description>An example showing how to use Resilience4j EIP as circuit breaker in Camel routes</description>
 

--- a/resilience4j/pom.xml
+++ b/resilience4j/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <category>EIP</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/resilience4j/pom.xml
+++ b/resilience4j/pom.xml
@@ -21,19 +21,17 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-resilience4j</artifactId>
     <packaging>pom</packaging>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Resilience4j</name>
     <description>An example showing how to use Resilience4j EIP as circuit breaker in Camel routes</description>
 
     <properties>
         <category>EIP</category>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <modules>

--- a/resilience4j/service1/pom.xml
+++ b/resilience4j/service1/pom.xml
@@ -28,6 +28,8 @@
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j-service1</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Resilience4j :: Service 1</name>
     <description>An example showing how to use Resilience4j EIP as circuit breaker in Camel routes</description>
 

--- a/resilience4j/service2/pom.xml
+++ b/resilience4j/service2/pom.xml
@@ -28,6 +28,8 @@
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j-service2</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Resilience4j :: Service 2</name>
     <description>An example showing how to use Resilience4j EIP as circuit breaker in Camel routes</description>
 

--- a/rest-cxf-opentelemetry/pom.xml
+++ b/rest-cxf-opentelemetry/pom.xml
@@ -20,13 +20,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-rest-cxf-opentelemetry</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: REST using CXF and OpenTelemetry</name>
     <description>An example showing Camel REST using CXF and OpenTelemetry with Spring Boot</description>
     <packaging>pom</packaging>
@@ -34,6 +30,11 @@
     <properties>
         <category>CXF</category>
         <opentelemetry-javaagent.version>2.7.0</opentelemetry-javaagent.version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+        <cxf-version>4.1.1.rbac-redhat-00005</cxf-version>
+        <camel-community-version>4.10.3</camel-community-version>
+		<build-helper-maven-plugin-version>3.6.0</build-helper-maven-plugin-version>
     </properties>
     
     <modules>

--- a/rest-cxf-opentelemetry/pom.xml
+++ b/rest-cxf-opentelemetry/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <category>CXF</category>
         <opentelemetry-javaagent.version>2.7.0</opentelemetry-javaagent.version>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
         <cxf-version>4.1.1.rbac-redhat-00005</cxf-version>
         <camel-community-version>4.10.3</camel-community-version>

--- a/rest-openapi-simple/pom.xml
+++ b/rest-openapi-simple/pom.xml
@@ -32,7 +32,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
         <maven-resources-plugin-version>3.3.1</maven-resources-plugin-version>
     </properties>

--- a/rest-openapi-simple/pom.xml
+++ b/rest-openapi-simple/pom.xml
@@ -20,13 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-rest-openapi-simple</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Rest :: OpenApi Simple</name>
     <description>This example shows how to call a Rest service defined using OpenApi specification</description>
 
@@ -36,7 +32,9 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+        <maven-resources-plugin-version>3.3.1</maven-resources-plugin-version>
     </properties>
 
     <dependencyManagement>

--- a/rest-openapi-springdoc/pom.xml
+++ b/rest-openapi-springdoc/pom.xml
@@ -19,19 +19,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-rest-openapi-springdoc</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: REST DSL and OpenApi</name>
     <description>An example showing Camel REST DSL and OpenApi with a Springdoc UI in a Spring Boot application</description>
 
     <properties>
         <category>Rest</category>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <!-- Spring-Boot and Camel BOM -->
@@ -104,7 +101,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot-version}</version>
+                <version>${spring-boot-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/rest-openapi-springdoc/pom.xml
+++ b/rest-openapi-springdoc/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <category>Rest</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/rest-openapi/pom.xml
+++ b/rest-openapi/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <category>Rest</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/rest-openapi/pom.xml
+++ b/rest-openapi/pom.xml
@@ -20,19 +20,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-rest-openapi</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: REST DSL and OpenApi</name>
     <description>An example showing Camel REST DSL and OpenApi with Spring Boot</description>
 
     <properties>
         <category>Rest</category>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <!-- Spring-Boot and Camel BOM -->
@@ -109,7 +106,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot-version}</version>
+                <version>${spring-boot-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/rest-spring-security/pom.xml
+++ b/rest-spring-security/pom.xml
@@ -21,18 +21,26 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
+		<groupId>org.apache.camel.springboot</groupId>
+		<artifactId>spring-boot</artifactId>
+		<version>4.10.3.redhat-00003</version>
+	</parent>
 
     <artifactId>camel-example-spring-boot-rest-spring-security</artifactId>
-    <name>Camel SB Examples :: REST DSL - SPRING SECURITY - JWT</name>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
+    <name>Camel SB Examples :: REST DSL - Spring Security - JWT</name>
     <description>An example showing Camel REST DSL secured with Spring Security and JWT token in a Spring Boot application
     </description>
 
     <properties>
         <category>Rest</category>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+        <json-unit-assertj.version>4.1.0</json-unit-assertj.version>
+        <testcontainers-keycloak.version>3.6.0</testcontainers-keycloak.version>
+        <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
+        <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
     </properties>
 
     <!-- Spring-Boot and Camel BOM -->

--- a/rest-spring-security/pom.xml
+++ b/rest-spring-security/pom.xml
@@ -29,7 +29,9 @@
 
     <properties>
         <category>Rest</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
         <json-unit-assertj.version>4.1.0</json-unit-assertj.version>
         <testcontainers-keycloak.version>3.6.0</testcontainers-keycloak.version>

--- a/rest-spring-security/pom.xml
+++ b/rest-spring-security/pom.xml
@@ -20,12 +20,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-		<groupId>org.apache.camel.springboot</groupId>
-		<artifactId>spring-boot</artifactId>
-		<version>4.10.3.redhat-00003</version>
-	</parent>
-
     <artifactId>camel-example-spring-boot-rest-spring-security</artifactId>
     <groupId>org.apache.camel.springboot.example</groupId>
     <version>4.10.3-SNAPSHOT</version>    
@@ -41,6 +35,7 @@
         <testcontainers-keycloak.version>3.6.0</testcontainers-keycloak.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
+        <mapstruct-version>1.6.3</mapstruct-version>
     </properties>
 
     <!-- Spring-Boot and Camel BOM -->

--- a/route-reload/pom.xml
+++ b/route-reload/pom.xml
@@ -34,7 +34,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/route-reload/pom.xml
+++ b/route-reload/pom.xml
@@ -22,13 +22,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-route-reload</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Route Reload</name>
     <description>Live reload of routes if file is updated and saved</description>
 
@@ -38,7 +34,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>
@@ -131,17 +128,17 @@
                 </executions>
             </plugin>
 
-            <plugin>
+            <!--plugin>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-maven-plugin</artifactId>
-                <version>${camel-community-version}</version>
+                <version>${camel-community-version}</version-->
                 <!-- allows to fail if not all routes are fully covered during testing -->
                 <!--
                         <configuration>
                           <failOnError>true</failOnError>
                         </configuration>
                 -->
-            </plugin>
+            <!--/plugin-->
         </plugins>
     </build>
 </project>

--- a/routes-configuration/pom.xml
+++ b/routes-configuration/pom.xml
@@ -32,7 +32,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/routes-configuration/pom.xml
+++ b/routes-configuration/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-routes-configuration</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Spring Boot :: Routes Configuration</name>
     <description>Example with global routes configuration for error handling</description>
 
@@ -36,6 +32,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/routetemplate-xml/pom.xml
+++ b/routetemplate-xml/pom.xml
@@ -32,7 +32,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/routetemplate-xml/pom.xml
+++ b/routetemplate-xml/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-routetemplate-xml</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Spring Boot :: Route Template :: XML</name>
     <description>How to use route templates (parameterized routes) in XML</description>
 
@@ -36,6 +32,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/routetemplate/pom.xml
+++ b/routetemplate/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-routetemplate</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Spring Boot :: Route Template</name>
     <description>How to use route templates (parameterized routes)</description>
 
@@ -36,7 +32,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/routetemplate/pom.xml
+++ b/routetemplate/pom.xml
@@ -32,7 +32,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -32,7 +32,7 @@
         <category>EIP</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-saga</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Saga</name>
     <description>This example shows how to work with a simple Apache Camel application using Spring Boot and Narayana LRA Coordinator to manage distributed actions implementing SAGA pattern</description>
     <packaging>pom</packaging>
@@ -36,6 +32,8 @@
         <category>EIP</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <modules>

--- a/saga/saga-app/pom.xml
+++ b/saga/saga-app/pom.xml
@@ -62,6 +62,11 @@
 					<name>openshift</name>
 				</property>
 			</activation>
+			<properties>
+				<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>

--- a/saga/saga-flight-service/pom.xml
+++ b/saga/saga-flight-service/pom.xml
@@ -63,6 +63,11 @@
 					<name>openshift</name>
 				</property>
 			</activation>
+			<properties>
+				<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>

--- a/saga/saga-payment-service/pom.xml
+++ b/saga/saga-payment-service/pom.xml
@@ -63,6 +63,11 @@
 					<name>openshift</name>
 				</property>
 			</activation>
+			<properties>
+				<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>

--- a/saga/saga-train-service/pom.xml
+++ b/saga/saga-train-service/pom.xml
@@ -63,6 +63,11 @@
 					<name>openshift</name>
 				</property>
 			</activation>
+			<properties>
+				<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>

--- a/servicecall/consumer/pom.xml
+++ b/servicecall/consumer/pom.xml
@@ -28,6 +28,8 @@
     </parent>
 
     <artifactId>camel-example-spring-boot-servicecall-consumer</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: ServiceCall :: Consumer</name>
     <description>An example showing how to work with Camel ServiceCall EIP and Spring Boot (Consumer)</description>
 
@@ -134,7 +136,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
-            <version>${camel-version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/servicecall/pom.xml
+++ b/servicecall/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <category>Cloud</category>
         <title>Spring Boot ServiceCall</title>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
         <camel-version>4.10.3.redhat-00005</camel-version>
     </properties>

--- a/servicecall/pom.xml
+++ b/servicecall/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-servicecall</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: ServiceCall</name>
     <description>An example showing how to work with Camel ServiceCall EIP and Spring Boot</description>
     <packaging>pom</packaging>
@@ -35,6 +31,9 @@
     <properties>
         <category>Cloud</category>
         <title>Spring Boot ServiceCall</title>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+        <camel-version>4.10.3.redhat-00005</camel-version>
     </properties>
 
     <modules>

--- a/servicecall/services/pom.xml
+++ b/servicecall/services/pom.xml
@@ -28,6 +28,8 @@
     </parent>
 
     <artifactId>camel-example-spring-boot-servicecall-services</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: ServiceCall :: Services</name>
     <description>An example showing how to work with Camel ServiceCall EIP and Spring Boot (Services)</description>
 
@@ -102,7 +104,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
-            <version>${camel-version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/soap-cxf/pom.xml
+++ b/soap-cxf/pom.xml
@@ -20,13 +20,10 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.apache.camel.springboot.example</groupId>
-		<artifactId>examples</artifactId>
-		<version>4.10.3-SNAPSHOT</version>
-	</parent>
 
+	<groupId>org.apache.camel.springboot.example</groupId>
 	<artifactId>camel-example-spring-boot-soap-cxf</artifactId>
+	<version>4.10.3-SNAPSHOT</version>
 	<name>Camel SB Examples :: SOAP CXF</name>
 	<description>An example showing the Camel SOAP CXF</description>
 
@@ -34,6 +31,10 @@
 		<category>CXF</category>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+		<awaitility-version>4.3.0</awaitility-version>
+		<cxf-version>4.1.1.rbac-redhat-00005</cxf-version>
 	</properties>
 
 	<dependencyManagement>

--- a/soap-cxf/pom.xml
+++ b/soap-cxf/pom.xml
@@ -31,9 +31,9 @@
 		<category>CXF</category>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+		<camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
-		<awaitility-version>4.3.0</awaitility-version>
+		<awaitility-version>4.3.0.redhat-00001</awaitility-version>
 		<cxf-version>4.1.1.rbac-redhat-00005</cxf-version>
 	</properties>
 

--- a/splitter-eip/pom.xml
+++ b/splitter-eip/pom.xml
@@ -21,14 +21,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<parent>
-		<artifactId>examples</artifactId>
-		<groupId>org.apache.camel.springboot.example</groupId>
-		<version>4.10.3-SNAPSHOT</version>
-	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
+	<groupId>org.apache.camel.springboot.example</groupId>
 	<artifactId>camel-example-spring-boot-splitter-eip</artifactId>
+	<version>4.10.3-SNAPSHOT</version>
 	<name>Camel SB Examples :: Camel Splitter EIP</name>
 	<description>An example showing Splitter EIP with Camel and Spring Boot</description>
 
@@ -38,6 +35,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<spring.boot-version>${spring-boot-version}</spring.boot-version>
+		<camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
 	</properties>
 
 	<dependencyManagement>

--- a/splitter-eip/pom.xml
+++ b/splitter-eip/pom.xml
@@ -35,7 +35,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<spring.boot-version>${spring-boot-version}</spring.boot-version>
-		<camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+		<camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
 	</properties>
 

--- a/spring-boot-jta-jpa-autoconfigure/pom.xml
+++ b/spring-boot-jta-jpa-autoconfigure/pom.xml
@@ -32,7 +32,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <category>Advanced</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/spring-boot-jta-jpa-autoconfigure/pom.xml
+++ b/spring-boot-jta-jpa-autoconfigure/pom.xml
@@ -22,13 +22,9 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>spring-boot-jta-jpa-autoconfigure</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: JTA</name>
     <description>An example showing JTA with Spring Boot Autoconfiguration</description>
 
@@ -36,6 +32,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <category>Advanced</category>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/spring-boot-jta-jpa-autoconfigure/pom.xml
+++ b/spring-boot-jta-jpa-autoconfigure/pom.xml
@@ -170,6 +170,9 @@
             </activation>
             <properties>
                 <spring.profiles.active>openshift</spring.profiles.active>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <dependencies>
             </dependencies>

--- a/spring-boot-jta-jpa-xml/pom.xml
+++ b/spring-boot-jta-jpa-xml/pom.xml
@@ -32,7 +32,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <category>Advanced</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/spring-boot-jta-jpa-xml/pom.xml
+++ b/spring-boot-jta-jpa-xml/pom.xml
@@ -22,13 +22,9 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>spring-boot-jta-jpa-xml</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: JTA</name>
     <description>An example showing JTA with Spring Boot using Spring XML configuration</description>
 
@@ -36,6 +32,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <category>Advanced</category>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/spring-boot-jta-jpa-xml/pom.xml
+++ b/spring-boot-jta-jpa-xml/pom.xml
@@ -167,6 +167,9 @@
             </activation>
             <properties>
                 <spring.profiles.active>openshift</spring.profiles.active>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <build>
                 <plugins>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Spring Boot</name>
     <description>An example showing how to work with Camel and Spring Boot</description>
 
@@ -36,7 +32,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -32,7 +32,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/spring-jdbc/pom.xml
+++ b/spring-jdbc/pom.xml
@@ -30,7 +30,7 @@
 		<category>Beginner</category>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+		<camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
 	</properties>
 

--- a/spring-jdbc/pom.xml
+++ b/spring-jdbc/pom.xml
@@ -20,13 +20,9 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.apache.camel.springboot.example</groupId>
-		<artifactId>examples</artifactId>
-		<version>4.10.3-SNAPSHOT</version>
-	</parent>
-
+	<groupId>org.apache.camel.springboot.example</groupId>
 	<artifactId>camel-example-spring-boot-spring-jdbc</artifactId>
+	<version>4.10.3-SNAPSHOT</version>
 	<name>Camel SB Examples :: Spring JDBC</name>
 	<description>Camel transacted routes integrating local Spring Transaction</description>
 
@@ -34,6 +30,8 @@
 		<category>Beginner</category>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
 	</properties>
 
 

--- a/strimzi/pom.xml
+++ b/strimzi/pom.xml
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8
         </project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/strimzi/pom.xml
+++ b/strimzi/pom.xml
@@ -22,13 +22,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.apache.camel.springboot.example</groupId>
-		<artifactId>examples</artifactId>
-		<version>4.10.3-SNAPSHOT</version>
-	</parent>
-
     <artifactId>camel-example-spring-boot-strimzi</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Strimzi</name>
     <description>Camel example which a route is defined in XML for Strimzi
         integration on Openshift/Kubernetes
@@ -39,7 +35,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8
         </project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
 
@@ -110,7 +107,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot-version}</version>
+                <version>${spring-boot-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/strimzi/pom.xml
+++ b/strimzi/pom.xml
@@ -142,6 +142,11 @@
         </profile>
         <profile>
             <id>openshift</id>
+            <properties>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/supervising-route-controller/pom.xml
+++ b/supervising-route-controller/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-supervising-route-controller</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Supervising Route Controller</name>
     <description>An example showing how to work with Camel's Supervising Route Controller and Spring Boot</description>
 
@@ -36,7 +32,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
         <jolokia-version>2.0.1</jolokia-version>
     </properties>
 
@@ -123,7 +120,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
-            <version>${camel-version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/supervising-route-controller/pom.xml
+++ b/supervising-route-controller/pom.xml
@@ -32,9 +32,9 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
-        <jolokia-version>2.0.1</jolokia-version>
+        <jolokia-version>2.2.8.redhat-00002</jolokia-version>
     </properties>
 
     <dependencyManagement>

--- a/tomcat-jdbc/pom.xml
+++ b/tomcat-jdbc/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-tomcat-jdbc</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Tomcat JDBC</name>
     <description>An example showing how to deploy a Camel Spring Boot application in Tomcat using its JDBC Data Source</description>
     <packaging>war</packaging>
@@ -37,6 +33,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/tomcat-jdbc/pom.xml
+++ b/tomcat-jdbc/pom.xml
@@ -33,7 +33,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/type-converter/pom.xml
+++ b/type-converter/pom.xml
@@ -15,7 +15,7 @@
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+		<camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
 		<build-helper-maven-plugin-version>3.6.0</build-helper-maven-plugin-version>
 		<camel-community-version>4.10.3</camel-community-version>

--- a/type-converter/pom.xml
+++ b/type-converter/pom.xml
@@ -2,13 +2,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<parent>
-		<artifactId>examples</artifactId>
-		<groupId>org.apache.camel.springboot.example</groupId>
-		<version>4.10.3-SNAPSHOT</version>
-	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
+	<groupId>org.apache.camel.springboot.example</groupId>
+	<version>4.10.3-SNAPSHOT</version>
 	<artifactId>camel-example-spring-boot-type-converter</artifactId>
 	<name>Camel SB Examples :: Custom Type Converter</name>
 	<description>An example showing how to create custom type converter with Camel and Spring Boot</description>
@@ -18,7 +15,10 @@
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<spring.boot-version>${spring-boot-version}</spring.boot-version>
+		<camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+		<build-helper-maven-plugin-version>3.6.0</build-helper-maven-plugin-version>
+		<camel-community-version>4.10.3</camel-community-version>
 	</properties>
 
 	<dependencyManagement>

--- a/update-properties.sh
+++ b/update-properties.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Default values (empty)
+SB_VERSION=""
+CSB_VERSION=""
+CAMEL_VERSION=""
+CXF_VERSION=""
+CAMEL_COMMUNITY_VERSION=""
+JKUBE_VERSION=""
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -sb)
+      SB_VERSION="$2"
+      shift 2
+      ;;
+    -csb)
+      CSB_VERSION="$2"
+      shift 2
+      ;;
+    -c)
+      CAMEL_VERSION="$2"
+      shift 2
+      ;;
+    -cxf)
+      CXF_VERSION="$2"
+      shift 2
+      ;;
+    -cc)
+      CAMEL_COMMUNITY_VERSION="$2"
+      shift 2
+      ;;
+    -j)
+      JKUBE_VERSION="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown parameter: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Prompt for any missing values
+if [ -z "$SB_VERSION" ]; then
+  read -p "Enter the Spring Boot version (ex. 3.4.4): " SB_VERSION
+fi
+
+if [ -z "$CSB_VERSION" ]; then
+  read -p "Enter the Camel Spring Boot version (ex. 4.10.3.redhat-00001): " CSB_VERSION
+fi
+
+if [ -z "$CAMEL_VERSION" ]; then
+  read -p "Enter the Camel version (ex. 4.10.3.redhat-00001): " CAMEL_VERSION
+fi
+
+if [ -z "$CXF_VERSION" ]; then
+  read -p "Enter the CXF version (ex. 4.1.1.rbac-redhat-00001): " CXF_VERSION
+fi
+
+if [ -z "$CAMEL_COMMUNITY_VERSION" ]; then
+  read -p "Enter the Camel Community version (ex. 4.10.3): " CAMEL_COMMUNITY_VERSION
+fi
+
+if [ -z "$JKUBE_VERSION" ]; then
+  read -p "Enter the JKube (Openshift Maven Plugin) version (ex. 1.18.1.redhat-00010): " JKUBE_VERSION
+fi
+
+PROPERTIES="hapi-version,guava-version,exec-maven-plugin-version,jolokia-version,metrics-version,lombok-mapstruct-binding.version,mapstruct-version,activemq-version,testcontainers-version,javafaker-version,apicurio-version,avro.maven.plugin-version,prometheus-version,reactor-version,build-helper-maven-plugin-version,maven-resources-plugin-version,awaitility-version"
+echo "Automatically updating the following properties $PROPERTIES"
+mvn versions:update-property -Dproperty=$PROPERTIES -DgenerateBackupPoms=false -DallowMajorUpdates=false -maven.version.ignore='(?i).*-(alpha|beta|m|rc)([-.]?\d+)?'
+
+echo "Spring Boot Version: $SB_VERSION"
+echo "CSB Version: $CSB_VERSION"
+echo "Camel Version: $CAMEL_VERSION"
+echo "CXF Version: $CXF_VERSION"
+echo "Camel Community Version: $CAMEL_COMMUNITY_VERSION"
+echo "JKube Version: $JKUBE_VERSION"
+mvn versions:set-property -Dproperty=camel-version -DnewVersion=$CAMEL_VERSION -DgenerateBackupPoms=false
+mvn versions:set-property -Dproperty=camel-spring-boot-version -DnewVersion=$CSB_VERSION -DgenerateBackupPoms=false
+mvn versions:set-property -Dproperty=camel-community-version -DnewVersion=$CAMEL_COMMUNITY_VERSION -DgenerateBackupPoms=false
+mvn versions:set-property -Dproperty=spring-boot-version -DnewVersion=$SB_VERSION -DgenerateBackupPoms=false
+mvn versions:set-property -Dproperty=cxf-version -DnewVersion=$CXF_VERSION -DgenerateBackupPoms=false
+mvn versions:set-property -Dproperty=jkube-maven-plugin-version -DnewVersion=$JKUBE_VERSION -DgenerateBackupPoms=false -DprofileId=openshift

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -139,7 +139,11 @@
                     <name>openshift</name>
                 </property>
             </activation>
-
+            <properties>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.springframework.boot</groupId>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -33,7 +33,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-validator</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Validator</name>
     <description>An example showing how to work with declarative validation and Spring Boot</description>
 
@@ -37,7 +33,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/webhook/pom.xml
+++ b/webhook/pom.xml
@@ -18,20 +18,19 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>examples</artifactId>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-example-spring-boot-webhook</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Webhook</name>
     <description>Example on how to use the Camel Webhook component</description>
     <packaging>jar</packaging>
 
     <properties>
         <category>Advanced</category>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>

--- a/webhook/pom.xml
+++ b/webhook/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <category>Advanced</category>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/widget-gadget/pom.xml
+++ b/widget-gadget/pom.xml
@@ -33,7 +33,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 

--- a/widget-gadget/pom.xml
+++ b/widget-gadget/pom.xml
@@ -148,6 +148,9 @@
             </activation>
             <properties>
                 <spring.profiles.active>openshift</spring.profiles.active>
+                <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+                <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
+                <jkube-maven-plugin-version>1.18.1.redhat-00010</jkube-maven-plugin-version>
             </properties>
             <dependencies>
             </dependencies>

--- a/widget-gadget/pom.xml
+++ b/widget-gadget/pom.xml
@@ -20,14 +20,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>examples</artifactId>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-example-spring-boot-widget-gadget</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: Widget Gadget</name>
     <description>The widget and gadget example from EIP book, running on Spring Boot</description>
 
@@ -36,7 +33,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
     </properties>
 
     <dependencyManagement>
@@ -104,7 +102,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
-            <version>${camel-version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/xml-import/pom.xml
+++ b/xml-import/pom.xml
@@ -33,7 +33,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
         <camel-community-version>4.10.3</camel-community-version>
     </properties>

--- a/xml-import/pom.xml
+++ b/xml-import/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-xml-import</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: XML Import</name>
     <description>An example showing how to work with Spring XML files imported with embedded CamelContext</description>
 
@@ -37,7 +33,9 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+        <camel-community-version>4.10.3</camel-community-version>
     </properties>
 
     <dependencyManagement>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -21,13 +21,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.apache.camel.springboot.example</groupId>
-        <artifactId>examples</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
-    </parent>
-
     <artifactId>camel-example-spring-boot-xml</artifactId>
+    <groupId>org.apache.camel.springboot.example</groupId>
+    <version>4.10.3-SNAPSHOT</version>    
     <name>Camel SB Examples :: XML</name>
     <description>An example showing how to work with Camel routes in XML files and Spring Boot</description>
 
@@ -37,7 +33,9 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <spring-boot-version>3.4.4</spring-boot-version>
+        <camel-community-version>4.10.3</camel-community-version>
     </properties>
 
     <dependencyManagement>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -33,7 +33,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00003</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00004</camel-spring-boot-version>
         <spring-boot-version>3.4.4</spring-boot-version>
         <camel-community-version>4.10.3</camel-community-version>
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/CSB-4993

I'd like to get rid of all the

```
    <parent>
		<groupId>org.apache.camel.springboot</groupId>
		<artifactId>spring-boot</artifactId>
		<version>4.10.3.redhat-00003</version>
	</parent>
```

for example, in fhir, but this means that I should add a new property `<hapi-version>1.2.3.4</hapi-version>` and we should somehow handle it. Do you have any thoughts?