### PR TITLE
Remove kubernetes profile from strimzi quickstart

### DIFF
--- a/strimzi/pom.xml
+++ b/strimzi/pom.xml
@@ -121,26 +121,6 @@
 
     <profiles>
         <profile>
-            <id>kubernetes</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.eclipse.jkube</groupId>
-                        <artifactId>kubernetes-maven-plugin</artifactId>
-                        <version>${jkube-maven-plugin-version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>resource</goal>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>openshift</id>
             <properties>
                 <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>


### PR DESCRIPTION
Removing the kubernetes profile - it uses properties which will not be available unless the openshift profile is also active and it is the only quickstart that has a kubernetes profile.     I don't think we need it and I think an openshift profile is sufficient.