### PR TITLE
Use most recent apicurio-registry (3.0.7)

### DIFF
--- a/kafka-avro/README.adoc
+++ b/kafka-avro/README.adoc
@@ -15,7 +15,7 @@ See the link:src/main/resources/application.properties[configuration file] and t
 Start the apicurio registry in a docker container:
 
 ----
-docker run -d -p 8080:8080 apicurio/apicurio-registry-mem:2.4.3.Final
+docker run -d -p 8080:8080 apicurio/apicurio-registry:3.0.7
 ----
 
 Start the kafka broker:

--- a/kafka-avro/pom.xml
+++ b/kafka-avro/pom.xml
@@ -34,7 +34,7 @@
         <camel-spring-boot-version>4.10.3.redhat-00010</camel-spring-boot-version>
         <spring-boot-version>3.4.5</spring-boot-version>
         <avro.maven.plugin-version>1.12.0.redhat-00001</avro.maven.plugin-version>
-        <apicurio-version>3.0.0.redhat-00001</apicurio-version>
+        <apicurio-version>3.0.7</apicurio-version>
         <javafaker-version>1.0.2</javafaker-version>
     </properties>
 
@@ -66,7 +66,7 @@
         </dependency>
         <dependency>
             <groupId>io.apicurio</groupId>
-            <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
+            <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
             <version>${apicurio-version}</version>
         </dependency>
 

--- a/kafka-avro/src/main/resources/application-local.properties
+++ b/kafka-avro/src/main/resources/application-local.properties
@@ -1,2 +1,3 @@
+server.port=8090
 camel.component.kafka.brokers=localhost:9092
 camel.component.kafka.additional-properties[apicurio.registry.url]=http://localhost:8080


### PR DESCRIPTION
@mcarlett - Roman reported this issue : 

https://jenkins-csb-fuse-qe-fuse-next.dno.corp.redhat.com/view/Camel%20Spring%20Boot/job/tnb/job/camel-springboot/job/rhaf-csb-4.10.x/job/examples/67/consoleFull

`Failed to execute goal on project camel-example-spring-boot-kafka-avro: Could not resolve dependencies for project org.apache.camel.springboot.example:camel-example-spring-boot-kafka-avro:jar:4.10.3.redhat-00010: Failed to collect dependencies at io.apicurio:apicurio-registry-serdes-avro-serde:jar:3.0.0.redhat-00001: Failed to read artifact descriptor for io.apicurio:apicurio-registry-serdes-avro-serde:jar:3.0.0.redhat-00001: The following artifacts could not be resolved: io.quarkus:quarkus-bom:pom:3.1.2.Final-redhat-00001 (absent): Could not find artifact io.quarkus:quarkus-bom:pom:3.1.2.Final-redhat-00001 in nexus-offliner`

I don't think we can support an apicurio productized version here - we aren't going to ship the entirety of apicurio and whatever gets pulled in from quarkus-bom in our MRRC for it.    I'd rather point at a recent community version of apicurio.

These changes get the apicurio registry to start up but I'm having trouble getting things to work with the kafka broker.    The README has us using bitnami/kafka:latest but it seems like the mandatory parameters for the kafka broker have changed since this quickstart was tried last - it'd probably be good if we specified a version of bitnami/kafka rather than just point at latest.      The broker won't start on my machine with the parameters in the README but I was able to get it to start with the following 

`podman run -d -e ALLOW_PLAINTEXT_LISTENER=yes -e KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092 -e KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true -e KAFKA_CFG_PROCESS_ROLES=broker,controller -e KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER -e KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093 -e KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT -e KAFKA_CFG_NODE_ID=0 -e KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093 -p 9092:9092 bitnami/kafka:latest`

I'm not having any success getting the employee rows added though - any ideas?