### PR TITLE
Remove unused camel-version from servicecall example

### DIFF
--- a/servicecall/pom.xml
+++ b/servicecall/pom.xml
@@ -33,7 +33,6 @@
         <title>Spring Boot ServiceCall</title>
         <camel-spring-boot-version>4.10.3.redhat-00010</camel-spring-boot-version>
         <spring-boot-version>3.4.5</spring-boot-version>
-        <camel-version>4.10.3.redhat-00015</camel-version>
     </properties>
 
     <modules>


### PR DESCRIPTION
https://jenkins-csb-fuse-qe-fuse-next.dno.corp.redhat.com/job/camel-springboot/job/rhaf-csb-4.10.x/job/acceptance-tests/30/consoleFull

Acceptance tests are failing because the camel-version in service-call is not aligned correctly.     camel-version is not used in service-call and should be removed - there's no dependency depending upon ${camel-version} so it will never align correctly.

