### PR TITLE
monitoring-micrometrics-grafana-prometheus : Remove camel-metrics-starter (unneeded and unsupported) and make a few other tweaks

### DIFF
--- a/monitoring-micrometrics-grafana-prometheus/README.adoc
+++ b/monitoring-micrometrics-grafana-prometheus/README.adoc
@@ -143,7 +143,7 @@ dummy_call_counter_total{camelContext="Camel-Monitoring-Example",} 2.0
 === Run locally on Docker
 
 Is possible to run the entire project with prometheus and grafana using docker maven plugin.
-In order to run it , you need to have a running docker daemon on your machine, then in a shell
+In order to run it, you need to have a running docker daemon on your machine and you need to enable the "Enable Host Networking" setting within Docker Settings -> Resources -> Network (if applicable).  Then in a shell
 you can run:
 
 [source,console]

--- a/monitoring-micrometrics-grafana-prometheus/pom.xml
+++ b/monitoring-micrometrics-grafana-prometheus/pom.xml
@@ -15,10 +15,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8
         </project.reporting.outputEncoding>
-        <camel-spring-boot-version>4.10.3.redhat-00019</camel-spring-boot-version>
+        <camel-spring-boot-version>4.10.3.redhat-00023</camel-spring-boot-version>
         <spring-boot-version>3.4.7</spring-boot-version>
         <jolokia-version>2.2.5.redhat-00001</jolokia-version>
         <prometheus-version>1.2.0.redhat-00001</prometheus-version>
+        <docker-maven-plugin.version>0.42.0</docker-maven-plugin.version>
         <docker.containerNamePattern>%a</docker.containerNamePattern>
         <jkube.replicas>3</jkube.replicas>
         <jkube.namespace>csb-monitoring</jkube.namespace>
@@ -67,10 +68,6 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-tracer-initializer</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-metrics-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -223,7 +220,7 @@
                                     <alias>app</alias>
                                     <name>csb-app</name>
                                     <build>
-                                        <from>eclipse-temurin:17.0.8.1_1-jre-alpine</from>
+                                        <from>eclipse-temurin:17-jre</from>
                                         <assemblies>
                                             <assembly>
                                                 <descriptorRef>artifact</descriptorRef>

--- a/monitoring-micrometrics-grafana-prometheus/src/main/java/org/apache/camel/example/spring/boot/monitoring/MonitoredRouteBuilder.java
+++ b/monitoring-micrometrics-grafana-prometheus/src/main/java/org/apache/camel/example/spring/boot/monitoring/MonitoredRouteBuilder.java
@@ -76,13 +76,5 @@ public class MonitoredRouteBuilder extends RouteBuilder {
                    }
                 }).id("random-failure-cpu");
 
-
-        from("timer:googleTimer?period={{metricsPeriod}}")
-                .routeId("dummy-api-call-route")
-                .process(e->{
-                    e.getMessage().setBody(new Random().nextInt(8), Integer.class);
-                }).id("generate-random-delay")
-                .toD("https://hub.dummyapis.com/delay?seconds=${body}&sslContextParameters=#dummyapisSslContext").id("to-dummy-api")
-                .to("micrometer:counter:dummy.call.counter").id("to-counter-dummy-api");
     }
 }


### PR DESCRIPTION
We're trying to remove the use of unsupported starters from the examples and this example currently uses camel-metrics-starter but it doesn't seem to actually need to use it.     This seems like a useful example which shows off functionality that still exists (using prometheus / grafana to collect metrics) so it seems like an example we should keep.

Remove the use of camel-metrics-starter, use a more recent app base image (eclipse-temurin:17-jre) that is supported on a wider array of architectures, add the necessary docker-maven-plugin version, remove the route to the dummy api (no longer reachable).

Also, include a note about the necessity of enabling host networking in docker for this example to work.