### PR TITLE
Show the actuator details within springdoc's swagger ui endpoint

### DIFF
--- a/rest-openapi-springdoc/src/main/resources/application.properties
+++ b/rest-openapi-springdoc/src/main/resources/application.properties
@@ -26,6 +26,9 @@ management.endpoints.web.exposure.include=camelroutes,jolokia,metrics,prometheus
 # turn on actuator health check
 management.endpoint.health.enabled = true
 
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.show-actuator=true
+
 # rest can also be configured here instead in the CamelRouter class
 # rest DSL configuration
 #camel.rest.component=servlet


### PR DESCRIPTION
Was playing around with this as part of https://issues.redhat.com/browse/CSB-7282 - adding the actuator endpoints.