### PR TITLE
Change arguments to match agroal 2.7.1 AgroalDataSourceAutoConfiguration

### DIFF
--- a/multi-datasource-2pc/src/main/java/sample/camel/DataSourcesConfig.java
+++ b/multi-datasource-2pc/src/main/java/sample/camel/DataSourcesConfig.java
@@ -1,5 +1,6 @@
 package sample.camel;
 
+import io.agroal.api.security.AgroalSecurityProvider;
 import io.agroal.springframework.boot.AgroalDataSource;
 import io.agroal.springframework.boot.AgroalDataSourceAutoConfiguration;
 import io.agroal.springframework.boot.jndi.AgroalDataSourceJndiBinder;
@@ -20,6 +21,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.jta.JtaTransactionManager;
 
+import java.util.ArrayList;
+
 import javax.sql.DataSource;
 
 @Configuration
@@ -37,12 +40,13 @@ public class DataSourcesConfig {
     @ConfigurationProperties("app.datasource.ds1.agroal")
     public AgroalDataSource firstDataSource(
         @Qualifier("ds1properties") DataSourceProperties properties,
-        JtaTransactionManager jtaPlatform,
-        XAResourceRecoveryRegistry xaResourceRecoveryRegistry,
-        ObjectProvider<AgroalDataSourceJndiBinder> jndiBinder) {
+        ObjectProvider<JtaTransactionManager> jtaPlatform,
+        ObjectProvider<XAResourceRecoveryRegistry> xaResourceRecoveryRegistry,
+        ObjectProvider<AgroalDataSourceJndiBinder> jndiBinder,
+        ObjectProvider<AgroalSecurityProvider> securityProvider) {
 
-        return new AgroalDataSourceAutoConfiguration(jtaPlatform, xaResourceRecoveryRegistry)
-            .dataSource(properties, false, false, jndiBinder);
+        return new AgroalDataSourceAutoConfiguration(jtaPlatform, xaResourceRecoveryRegistry, jndiBinder, securityProvider)
+            .dataSource(properties, true, false, false, new ArrayList<Object>(), new ArrayList<Object>());
     }
 
     @Bean("ds1jdbc")
@@ -68,12 +72,13 @@ public class DataSourcesConfig {
     @ConfigurationProperties("app.datasource.ds2.agroal")
     public AgroalDataSource secondDataSource(
         @Qualifier("ds2properties") DataSourceProperties properties,
-        JtaTransactionManager jtaPlatform,
-        XAResourceRecoveryRegistry xaResourceRecoveryRegistry,
-        ObjectProvider<AgroalDataSourceJndiBinder> jndiBinder) {
+        ObjectProvider<JtaTransactionManager> jtaPlatform,
+        ObjectProvider<XAResourceRecoveryRegistry> xaResourceRecoveryRegistry,
+        ObjectProvider<AgroalDataSourceJndiBinder> jndiBinder,
+        ObjectProvider<AgroalSecurityProvider> securityProvider) {
 
-        return new AgroalDataSourceAutoConfiguration(jtaPlatform, xaResourceRecoveryRegistry)
-            .dataSource(properties, false, false, jndiBinder);
+        return new AgroalDataSourceAutoConfiguration(jtaPlatform, xaResourceRecoveryRegistry, jndiBinder, securityProvider)
+            .dataSource(properties, true, false, false, new ArrayList<Object>(), new ArrayList<Object>());
     }
 
     @Bean("ds2jdbc")


### PR DESCRIPTION
There were a few API changes in agroal 2.6 for AgroalDataSourceAutoConfiguration - change the number of arguments to match.

Can someone check that this looks okay?   Test passes locally for me and I see the unique constraint being violated like the README describes. 