### PR TITLE
Show the actuator details within springdoc's swagger ui endpoint (#225)

### DIFF
--- a/rest-openapi-springdoc/src/main/resources/application.properties
+++ b/rest-openapi-springdoc/src/main/resources/application.properties
@@ -26,6 +26,9 @@ management.endpoints.web.exposure.include=camelroutes,jolokia,metrics,prometheus
 # turn on actuator health check
 management.endpoint.health.enabled = true
 
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.show-actuator=true
+
 # rest can also be configured here instead in the CamelRouter class
 # rest DSL configuration
 #camel.rest.component=servlet


### PR DESCRIPTION
This PR https://github.com/jboss-fuse/camel-spring-boot-examples/pull/225 didn't make it into camel-spring-boot-examples-4.10.3-branch before we created the 4.10.6 branch - cherry pick it over.