### PR TITLE
CSB-7282 Remove usage of camel-stream-starter from examples, substitute in camel-log usage (#224)

### DIFF
--- a/jolokia/pom.xml
+++ b/jolokia/pom.xml
@@ -69,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-stream-starter</artifactId>
+            <artifactId>camel-log-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>

--- a/jolokia/src/main/java/org/apache/camel/example/MySpringBootRouter.java
+++ b/jolokia/src/main/java/org/apache/camel/example/MySpringBootRouter.java
@@ -34,7 +34,7 @@ public class MySpringBootRouter extends RouteBuilder {
             .filter(simple("${body} contains 'foo'"))
                 .to("log:foo")
             .end()
-            .to("stream:out");
+            .to("log:out");
     }
 
 }

--- a/pojo/pom.xml
+++ b/pojo/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-stream-starter</artifactId>
+            <artifactId>camel-log-starter</artifactId>
         </dependency>
         <!-- monitoring -->
         <dependency>

--- a/pojo/src/main/java/sample/camel/NumberPojo.java
+++ b/pojo/src/main/java/sample/camel/NumberPojo.java
@@ -28,10 +28,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class NumberPojo {
 
-    // sends the message to the stream:out endpoint but hidden behind this interface
+    // sends the message to the log:out endpoint but hidden behind this interface
     // so the client java code below can use the interface method instead of Camel's
     // FluentProducerTemplate or ProducerTemplate APIs
-    @Produce("stream:out")
+    @Produce("log:out")
     private MagicNumber magic;
 
     // only consume when the predicate matches, e.g. when the message body is lower than 100

--- a/route-reload/pom.xml
+++ b/route-reload/pom.xml
@@ -74,7 +74,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-stream-starter</artifactId>
+            <artifactId>camel-log-starter</artifactId>
         </dependency>
         <!-- monitoring -->
         <dependency>

--- a/route-reload/src/main/resources/camel/my-route.xml
+++ b/route-reload/src/main/resources/camel/my-route.xml
@@ -31,7 +31,7 @@
         <simple>${body} contains 'foo'</simple>
         <to uri="log:foo?showHeaders=true"/>
       </filter>
-      <to uri="stream:out"/>
+      <to uri="log:out"/>
     </route>
 
 </routes>

--- a/splitter-eip/pom.xml
+++ b/splitter-eip/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-stream-starter</artifactId>
+            <artifactId>camel-log-starter</artifactId>
         </dependency>
         <!-- monitoring -->
         <dependency>

--- a/spring-boot/README.adoc
+++ b/spring-boot/README.adoc
@@ -12,7 +12,7 @@ The example generates messages using timer trigger, writes them to standard outp
 
 The Camel route is located in the `MyCamelRouter` class. In this class the route
 starts from a timer, that triggers every 2nd second and calls a Spring Bean `MyBean`
-which returns a message, that is routed to a stream endpoint which writes to standard output.
+which returns a message, that is routed to a log endpoint which writes to standard output.
 
 === Using Camel components
 

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -69,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-stream-starter</artifactId>
+            <artifactId>camel-log-starter</artifactId>
         </dependency>
         <!-- monitoring -->
         <dependency>

--- a/spring-boot/src/main/java/sample/camel/MyCamelRouter.java
+++ b/spring-boot/src/main/java/sample/camel/MyCamelRouter.java
@@ -38,8 +38,8 @@ public class MyCamelRouter extends RouteBuilder {
         from("timer:hello?period={{myPeriod}}").routeId("hello")
                 // and call the bean
                 .bean(myBean, "saySomething")
-                // and print it to system out via stream component
-                .to("stream:out");
+                // and print it to system out via log component
+                .to("log:out");
     }
 
 }

--- a/supervising-route-controller/pom.xml
+++ b/supervising-route-controller/pom.xml
@@ -85,7 +85,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-stream-starter</artifactId>
+            <artifactId>camel-log-starter</artifactId>
         </dependency>
         <!-- monitoring -->
         <dependency>

--- a/type-converter/pom.xml
+++ b/type-converter/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-stream-starter</artifactId>
+            <artifactId>camel-log-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>

--- a/validator/README.adoc
+++ b/validator/README.adoc
@@ -12,7 +12,7 @@ The example generates messages using timer trigger, writes them to standard outp
 
 The Camel route is located in the `SampleCamelRouter` class. In this class the route
 starts from a timer, that triggers every 2nd second and calls a Spring Bean `SampleBean`
-which returns a message, that is routed to a stream endpoint which writes to standard output.
+which returns a message, that is routed to a log endpoint which writes to standard output.
 The output type is declared as `greeting`, and the validator `GreetingValidator` is registered
 to be triggered for `greeting` output message right after the routing. 
 

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-stream-starter</artifactId>
+            <artifactId>camel-log-starter</artifactId>
         </dependency>
         <!-- monitoring -->
         <dependency>

--- a/validator/src/main/java/sample/camel/SampleCamelRouter.java
+++ b/validator/src/main/java/sample/camel/SampleCamelRouter.java
@@ -36,7 +36,7 @@ public class SampleCamelRouter extends RouteBuilder {
         from("timer:hello?period={{timer.period}}")
             .outputTypeWithValidate("greeting")
             .transform(method("myBean", "saySomething"))
-            .to("stream:out");
+            .to("log:out");
     }
 
 }

--- a/xml-import/README.adoc
+++ b/xml-import/README.adoc
@@ -12,7 +12,7 @@ The example generates messages using timer trigger, writes them to standard outp
 
 The Camel route is located in the `SampleCamelRouter` class. In this class the route
 starts from a timer, that triggers every 2nd second and calls a Spring Bean `SampleBean`
-which returns a message, that is routed to a stream endpoint which writes to standard output.
+which returns a message, that is routed to a log endpoint which writes to standard output.
 
 === Using Camel components
 

--- a/xml-import/pom.xml
+++ b/xml-import/pom.xml
@@ -72,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-stream-starter</artifactId>
+            <artifactId>camel-log-starter</artifactId>
         </dependency>
         <!-- monitoring -->
         <dependency>

--- a/xml-import/src/main/resources/my-camel.xml
+++ b/xml-import/src/main/resources/my-camel.xml
@@ -33,7 +33,7 @@
         <simple>${body} contains 'foo'</simple>
         <to uri="log:foo"/>
       </filter>
-      <to uri="stream:out"/>
+      <to uri="log:out"/>
     </route>
   </camelContext>
 

--- a/xml/README.adoc
+++ b/xml/README.adoc
@@ -12,7 +12,7 @@ The example generates messages using timer trigger, writes them to standard outp
 
 The Camel route is located in the `SampleCamelRouter` class. In this class the route
 starts from a timer, that triggers every 2nd second and calls a Spring Bean `SampleBean`
-which returns a message, that is routed to a stream endpoint which writes to standard output.
+which returns a message, that is routed to a log endpoint which writes to standard output.
 
 === Using Camel components
 

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -75,7 +75,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-stream-starter</artifactId>
+            <artifactId>camel-log-starter</artifactId>
         </dependency>
         <!-- monitoring -->
         <dependency>

--- a/xml/src/main/resources/camel/my-route.xml
+++ b/xml/src/main/resources/camel/my-route.xml
@@ -37,7 +37,7 @@
             </transform>
         </filter>
 
-        <to uri="stream:out"/>
+        <to uri="log:out"/>
     </route>
 
 </routes>


### PR DESCRIPTION
This PR https://github.com/jboss-fuse/camel-spring-boot-examples/pull/224 didn't make it into camel-spring-boot-examples-4.10.3-branch before the 4.10.6 branch was created - cherry pick it over.