### PR TITLE
Change ReadMe text

### DIFF
--- a/multi-datasource-2pc/README.adoc
+++ b/multi-datasource-2pc/README.adoc
@@ -6,7 +6,7 @@ This example shows how to set up multiple pooled datasources with Camel Spring B
 
 === Introduction
 
-One of the databases has a non-unique `name` column, while the other has a unique one. When trying to insert repeated names in both databases at the same time, the second `prepare` should fail making the transaction rollback for both databases.
+The first database has a non-unique `name` column, while the second has a unique one.  When trying to insert repeated names in both databases at the same time, the second `prepare` should fail making the transaction rollback for both databases.
 
 === Classes and resources
 


### PR DESCRIPTION
Small change to the text of the readme in order to trigger a new run of tests.      The tests failed https://jenkins-csb-fuse-ci.dno.corp.redhat.com/blue/organizations/jenkins/CamelSpringBoot%2Fcamel-spring-boot-examples/detail/PR-229/1/pipeline on their last run because of a dockerhub limit being exceeded - I've set up a mirror registry on fuse-build-repository that's already built into the Jenkins nodes that hopefully should solve this.