### PR TITLE
observation: manages protobuf compatibility

### DIFF
--- a/observation/pom.xml
+++ b/observation/pom.xml
@@ -31,6 +31,8 @@
         <title>Micrometer Observation</title>
         <camel-spring-boot-version>4.14.0.redhat-00005</camel-spring-boot-version>
         <spring-boot-version>3.5.5</spring-boot-version>
+        <!-- to manage compatibility with io.micrometer:micrometer-registry-otlp -->
+        <protobuf-java.version>4.31.1</protobuf-java.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -40,6 +42,11 @@
                 <version>${camel-spring-boot-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuf-java.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
if you declare `io.micrometer:micrometer-registry-otlp` dependency you need to manage `com.google.protobuf:protobuf-java` version otherwise the application won't start with

```
org.springframework.beans.BeanInstantiationException: Failed to instantiate [io.micrometer.registry.otlp.OtlpMeterRegistry]: Factory method 'otlpMeterRegistry' threw exception with message: com/google/protobuf/RuntimeVersion$RuntimeDomain
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.lambda$instantiate$0(SimpleInstantiationStrategy.java:200) ~[spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiateWithFactoryMethod(SimpleInstantiationStrategy.java:89) ~[spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:169) ~[spring-beans-6.2.10.jar:6.2.10]
	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:653) ~[spring-beans-6.2.10.jar:6.2.10]
	... 89 common frames omitted
Caused by: java.lang.NoClassDefFoundError: com/google/protobuf/RuntimeVersion$RuntimeDomain
```