### PR TITLE
Disable test requiring postgres image

### DIFF
--- a/multi-datasource-2pc/src/test/java/sample/camel/MyCamelApplicationJUnit5Test.java
+++ b/multi-datasource-2pc/src/test/java/sample/camel/MyCamelApplicationJUnit5Test.java
@@ -32,6 +32,7 @@ import org.junit.After;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -59,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @SpringBootTest(classes = MyCamelApplication.class)
 @EnableRouteCoverage
 @ActiveProfiles("test")
+@Disabled
 public class MyCamelApplicationJUnit5Test {
 
     @Container


### PR DESCRIPTION
Disable the test requiring postgres image - we are overrunning our unauthenticated docker image quota.