### PR TITLE
Fix validator example

### DIFF
--- a/validator/README.adoc
+++ b/validator/README.adoc
@@ -29,7 +29,7 @@ You can run this example using
 
 You can run this example with validation failure using
 
-    mvn spring-boot:run -Dspring-boot.run.arguments=Hello_Mars
+    mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Dgreeting=Hello_Mars"
 
 === How to run on Openshift
 

--- a/validator/src/main/java/sample/camel/SampleCamelRouter.java
+++ b/validator/src/main/java/sample/camel/SampleCamelRouter.java
@@ -34,6 +34,8 @@ public class SampleCamelRouter extends RouteBuilder {
             .withBean("greetingValidator");
         
         from("timer:hello?period={{timer.period}}")
+            .log("Current greeting value: {{greeting}}")
+            .log("Current valid value: {{greeting.valid}}")
             .outputTypeWithValidate("greeting")
             .transform(method("myBean", "saySomething"))
             .to("log:out");

--- a/validator/src/main/jkube/deployment.yml
+++ b/validator/src/main/jkube/deployment.yml
@@ -3,7 +3,7 @@ spec:
     spec:
       containers:
         - env:
-            - name: JAVA_OPTIONS
+            - name: JAVA_OPTS_APPEND
               value: " -Dgreeting=@greeting@ "
           livenessProbe:
             httpGet:


### PR DESCRIPTION
> mvn spring-boot:run -Dspring-boot.run.arguments=Hello_Mars

Command didn't work as expected

> name: JAVA_OPTIONS

Didn't allow to change property name. 
According to 
https://access.redhat.com/solutions/7041059
https://docs.redhat.com/en/documentation/red_hat_data_grid/7.2/html-single/data_grid_for_openshift/index#env-var-config
JAVA_OPTS_APPEND should be used in case some new -D properties should be added.
