### PR TITLE
Setting max http post size due to undertow upgrade, plus multipart co…

### DIFF
--- a/http-streaming/upload/backend-server/src/main/java/org/apache/camel/springboot/example/http/streaming/UndertowConfig.java
+++ b/http-streaming/upload/backend-server/src/main/java/org/apache/camel/springboot/example/http/streaming/UndertowConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.springboot.example.http.streaming;
+
+import io.undertow.UndertowOptions;
+import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class UndertowConfig {
+	@Bean
+	public WebServerFactoryCustomizer<UndertowServletWebServerFactory> undertowCustomizer() {
+		return factory -> factory.addBuilderCustomizers(builder ->
+			builder.setServerOption(UndertowOptions.MULTIPART_MAX_ENTITY_SIZE, -1L));
+	}
+}

--- a/http-streaming/upload/backend-server/src/main/resources/application.properties
+++ b/http-streaming/upload/backend-server/src/main/resources/application.properties
@@ -32,3 +32,4 @@ spring.mvc.async.request-timeout=-1
 
 # Backend port
 server.port=8080
+server.undertow.max-http-post-size=15GB


### PR DESCRIPTION
Probably due to this [change](https://github.com/undertow-io/undertow/commit/623985c23d9b42e193c3dc5cf9a2052ddc599342)

It was introduced a Configuration class setting `UndertowOptions.MULTIPART_MAX_ENTITY_SIZE` set to -1L through the WebServerFactoryCustomizer bean to overrides Undertow's new 2 MB DEFAULT_MULTIPART_MAX_ENTITY_SIZE (If we want to mantain, in this example, multipart requests)
 
