### PR TITLE
Fix compilation error due to AgroalDataSourceAutoConfiguration argument changes

### DIFF
--- a/multi-datasource-2pc/src/main/java/sample/camel/DataSourcesConfig.java
+++ b/multi-datasource-2pc/src/main/java/sample/camel/DataSourcesConfig.java
@@ -21,8 +21,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.jta.JtaTransactionManager;
 
-import java.util.ArrayList;
-
 import javax.sql.DataSource;
 
 @Configuration
@@ -45,8 +43,8 @@ public class DataSourcesConfig {
         ObjectProvider<AgroalDataSourceJndiBinder> jndiBinder,
         ObjectProvider<AgroalSecurityProvider> securityProvider) {
 
-        return new AgroalDataSourceAutoConfiguration(jtaPlatform, xaResourceRecoveryRegistry, jndiBinder, securityProvider)
-            .dataSource(properties, true, false, false, new ArrayList<Object>(), new ArrayList<Object>());
+        return new AgroalDataSourceAutoConfiguration(jtaPlatform.getIfAvailable(), xaResourceRecoveryRegistry.getIfAvailable())
+            .dataSource(properties, true, false, jndiBinder);
     }
 
     @Bean("ds1jdbc")
@@ -77,8 +75,8 @@ public class DataSourcesConfig {
         ObjectProvider<AgroalDataSourceJndiBinder> jndiBinder,
         ObjectProvider<AgroalSecurityProvider> securityProvider) {
 
-        return new AgroalDataSourceAutoConfiguration(jtaPlatform, xaResourceRecoveryRegistry, jndiBinder, securityProvider)
-            .dataSource(properties, true, false, false, new ArrayList<Object>(), new ArrayList<Object>());
+        return new AgroalDataSourceAutoConfiguration(jtaPlatform.getIfAvailable(), xaResourceRecoveryRegistry.getIfAvailable())
+            .dataSource(properties, true, false, jndiBinder);
     }
 
     @Bean("ds2jdbc")


### PR DESCRIPTION
Fix compilation error due to AgroalDataSourceAutoConfiguration argument changes

We're getting some build errors in PNC trying to build the multi-datasource-2pc example - fix the constructors to use the correct number of parameters.

https://orch-secondary.pnc.engineering.redhat.com/pnc-web/#/projects/1137/build-configs/20829/builds/BN2LDQE23WQAK/build-log

`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project camel-example-spring-boot-muti-datasources-2pc: Compilation failure: Compilation failure: 
[ERROR] /tmp/camel-spring-boot-examples-4.18.1/multi-datasource-2pc/src/main/java/sample/camel/DataSourcesConfig.java:[48,16] constructor AgroalDataSourceAutoConfiguration in class io.agroal.springframework.boot.AgroalDataSourceAutoConfiguration cannot be applied to given types;
[ERROR]   required: org.springframework.transaction.jta.JtaTransactionManager,org.jboss.tm.XAResourceRecoveryRegistry
[ERROR]   found:    org.springframework.beans.factory.ObjectProvider<org.springframework.transaction.jta.JtaTransactionManager>,org.springframework.beans.factory.ObjectProvider<org.jboss.tm.XAResourceRecoveryRegistry>,org.springframework.beans.factory.ObjectProvider<io.agroal.springframework.boot.jndi.AgroalDataSourceJndiBinder>,org.springframework.beans.factory.ObjectProvider<io.agroal.api.security.AgroalSecurityProvider>
[ERROR]   reason: actual and formal argument lists differ in length
[ERROR] /tmp/camel-spring-boot-examples-4.18.1/multi-datasource-2pc/src/main/java/sample/camel/DataSourcesConfig.java:[80,16] constructor AgroalDataSourceAutoConfiguration in class io.agroal.springframework.boot.AgroalDataSourceAutoConfiguration cannot be applied to given types;
[ERROR]   required: org.springframework.transaction.jta.JtaTransactionManager,org.jboss.tm.XAResourceRecoveryRegistry
[ERROR]   found:    org.springframework.beans.factory.ObjectProvider<org.springframework.transaction.jta.JtaTransactionManager>,org.springframework.beans.factory.ObjectProvider<org.jboss.tm.XAResourceRecoveryRegistry>,org.springframework.beans.factory.ObjectProvider<io.agroal.springframework.boot.jndi.AgroalDataSourceJndiBinder>,org.springframework.beans.factory.ObjectProvider<io.agroal.api.security.AgroalSecurityProvider>
[ERROR]   reason: actual and formal argument lists differ in length
[ERROR] -> [Help 1]`