### PR TITLE
Fixes Apicurio version for build-from-sources

### DIFF
--- a/kafka-avro/pom.xml
+++ b/kafka-avro/pom.xml
@@ -31,7 +31,7 @@
         <camel-spring-boot-version>4.18.1.redhat-00006</camel-spring-boot-version>
         <spring-boot-version>3.5.13</spring-boot-version>
         <avro.maven.plugin-version>1.12.1</avro.maven.plugin-version>
-        <apicurio-version>3.0.0.redhat-00001</apicurio-version>
+        <apicurio-version>2.6.13.redhat-00002</apicurio-version>
         <javafaker-version>1.0.2</javafaker-version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
Downgrade `apicurio-version` from `3.0.0.redhat-00001` to `2.6.13.redhat-00002` in the kafka-avro example