### PR TITLE
Add MVNW_REPOURL for mvnw - prevent 429 errors when downloading mvn zip

### DIFF
--- a/Jenkinsfile.redhat
+++ b/Jenkinsfile.redhat
@@ -28,6 +28,7 @@ pipeline {
 
     environment {
         MAVEN_OPTS = '-Xmx3g'
+        MVNW_REPOURL = 'https://nexus.corp.redhat.com/repository/maven-central/'
     }
 
     options {


### PR DESCRIPTION
Add MVNW_REPOURL for mvnw - prevent 429 errors when downloading mvn zip