### PR TITLE
CAMEL-23526: align CXF header constant names

### DIFF
--- a/rest-cxf-opentelemetry/pom.xml
+++ b/rest-cxf-opentelemetry/pom.xml
@@ -28,9 +28,9 @@
     <properties>
         <category>CXF</category>
         <opentelemetry-javaagent.version>2.19.0</opentelemetry-javaagent.version>
-        <camel-spring-boot-version>4.18.1.redhat-00006</camel-spring-boot-version>
+        <camel-spring-boot-version>4.18.1.redhat-00024</camel-spring-boot-version>
         <spring-boot-version>3.5.15</spring-boot-version>
-        <cxf-version>4.1.7.rhbac-redhat-00001</cxf-version>
+        <cxf-version>4.1.7.rhbac-redhat-00002</cxf-version>
         <camel-community-version>4.18.1</camel-community-version>
         <build-helper-maven-plugin-version>3.6.0</build-helper-maven-plugin-version>
     </properties>

--- a/rest-cxf-opentelemetry/rest-cxf-otel-even/src/main/java/org/apache/camel/example/springboot/cxf/otel/CamelRouter.java
+++ b/rest-cxf-opentelemetry/rest-cxf-otel-even/src/main/java/org/apache/camel/example/springboot/cxf/otel/CamelRouter.java
@@ -48,7 +48,7 @@ public class CamelRouter extends RouteBuilder {
                     "&loggingFeatureEnabled=true")
                 .to("log:camel-cxf-log?showAll=true")
                 .toD("bean:org.apache.camel.example.springboot.cxf.otel.EvenServiceImpl" +
-                        "?method=${header.operationName}");
+                        "?method=${header.CamelCxfOperationName}");
 
 
         from("direct:register").routeId("even-register")

--- a/rest-cxf-opentelemetry/rest-cxf-otel-odd/src/main/java/org/apache/camel/example/springboot/cxf/otel/CamelRouter.java
+++ b/rest-cxf-opentelemetry/rest-cxf-otel-odd/src/main/java/org/apache/camel/example/springboot/cxf/otel/CamelRouter.java
@@ -48,7 +48,7 @@ public class CamelRouter extends RouteBuilder {
                     "&loggingFeatureEnabled=true")
                 .to("log:camel-cxf-log?showAll=true")
                 .toD("bean:org.apache.camel.example.springboot.cxf.otel.OddServiceImpl" +
-                        "?method=${header.operationName}");
+                        "?method=${header.CamelCxfOperationName}");
 
 
         from("direct:register").routeId("odd-register")

--- a/rest-cxf-opentelemetry/rest-cxf-otel-random/src/main/java/org/apache/camel/example/springboot/cxf/otel/CamelRouter.java
+++ b/rest-cxf-opentelemetry/rest-cxf-otel-random/src/main/java/org/apache/camel/example/springboot/cxf/otel/CamelRouter.java
@@ -51,7 +51,7 @@ public class CamelRouter extends RouteBuilder {
                     "&providers=jaxrsProvider,openTelemetryProvider" +
                     "&loggingFeatureEnabled=true")
                 .to("log:camel-cxf-log?showAll=true")
-                .setHeader("methodName", simple("${header.operationName}"))
+                .setHeader("methodName", simple("${header.CamelCxfOperationName}"))
                 .toD("bean:org.apache.camel.example.springboot.cxf.otel.RandomServiceImpl?method=${header.methodName}");
 
 

--- a/soap-cxf/pom.xml
+++ b/soap-cxf/pom.xml
@@ -28,9 +28,9 @@
     <category>CXF</category>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <camel-spring-boot-version>4.18.1.redhat-00006</camel-spring-boot-version>
+    <camel-spring-boot-version>4.18.1.redhat-00024</camel-spring-boot-version>
     <spring-boot-version>3.5.15</spring-boot-version>
-    <cxf-version>4.1.7.rhbac-redhat-00001</cxf-version>
+    <cxf-version>4.1.7.rhbac-redhat-00002</cxf-version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/soap-cxf/src/main/java/sample/camel/MyPojoRouteBuilder.java
+++ b/soap-cxf/src/main/java/sample/camel/MyPojoRouteBuilder.java
@@ -42,6 +42,6 @@ public class MyPojoRouteBuilder extends RouteBuilder {
 	@Override
 	public void configure() throws Exception {
 		from("cxf:bean:contact")
-				.recipientList(simple("bean:inMemoryContactService?method=${header.operationName}"));
+				.recipientList(simple("bean:inMemoryContactService?method=${header.CamelCxfOperationName}"));
 	}
 }

--- a/soap-cxf/src/main/java/sample/camel/MyWsdlRouteBuilder.java
+++ b/soap-cxf/src/main/java/sample/camel/MyWsdlRouteBuilder.java
@@ -62,7 +62,7 @@ public class MyWsdlRouteBuilder extends RouteBuilder {
 	public void configure() throws Exception {
 		// CustomerService is generated with cxf-codegen-plugin during the build
 		from("cxf:bean:customers")
-				.recipientList(simple("direct:${header.operationName}"));
+				.recipientList(simple("direct:${header.CamelCxfOperationName}"));
 
 		from("direct:getCustomersByName").process(exchange -> {
 			String name = exchange.getIn().getBody(String.class);


### PR DESCRIPTION
## Summary
- Update `operationName` to `CamelCxfOperationName` following the `CxfConstants.OPERATION_NAME` rename in Camel 4.18.1 (CAMEL-23526)
- Update `camel-spring-boot-version` to `4.18.1.redhat-00024` and `cxf-version` to `4.1.7.rhbac-redhat-00002` for rest-cxf-opentelemetry and soap-cxf examples

## Changes
- 3 `CamelRouter.java` files in `rest-cxf-opentelemetry/` submodules
- 2 route builder files in `soap-cxf/`
- 2 `pom.xml` version bumps (rest-cxf-opentelemetry, soap-cxf)