### PR TITLE
Make Jira example issue priority configurable

### DIFF
--- a/jira/src/main/java/org/apache/camel/example/jira/AddIssueRoute.java
+++ b/jira/src/main/java/org/apache/camel/example/jira/AddIssueRoute.java
@@ -40,6 +40,9 @@ public class AddIssueRoute extends RouteBuilder {
     @Value("${example.jira.issue-type}")
     private String issueType;
 
+    @Value("${example.jira.issue-priority:Low}")
+    private String issuePriority;
+
     @Override
     public void configure() {
 
@@ -49,7 +52,7 @@ public class AddIssueRoute extends RouteBuilder {
                 .setHeader(ISSUE_PROJECT_KEY, () -> project)
                 .setHeader(ISSUE_TYPE_NAME, () -> issueType)
                 .setHeader(ISSUE_SUMMARY, () -> "Example Demo Bug jira " + (new Date()))
-                .setHeader(ISSUE_PRIORITY_NAME, () -> "Low")
+                .setHeader(ISSUE_PRIORITY_NAME, () -> issuePriority)
 
                 // uncomment to add a component
                 // .setHeader(ISSUE_COMPONENTS, () -> {

--- a/jira/src/main/resources/application.properties
+++ b/jira/src/main/resources/application.properties
@@ -26,6 +26,7 @@ camel.component.jira.jira-url=https\://test.com
 # example specific properties
 example.jira.project-key=COM
 example.jira.issue-type=Bug
+example.jira.issue-priority=Low
 example.jira.upload-directory=/tmp
 example.jira.upload-file-name=my_file.png
 example.jira.issue-attach=COM-79


### PR DESCRIPTION
## Summary
- The FUSEQE project on `stage-redhat.atlassian.net` uses a custom priority scheme (Blocker, Critical, Major, Normal, Minor, Undefined) that does not include `Low`
- The `AddIssueRoute` hardcoded priority to `Low`, causing issue creation to fail with "The priority selected is invalid"
- Make the priority configurable via `example.jira.issue-priority` property (defaults to `Low` for backward compatibility)

## Changes
- `AddIssueRoute.java`: inject priority from `${example.jira.issue-priority:Low}` instead of hardcoding
- `application.properties`: add `example.jira.issue-priority=Low` default

## Test plan
- [x] Ran `JiraExampleITCase` locally against `stage-redhat.atlassian.net` with priority set to `Minor` — all 3 tests pass