### PR TITLE
Fix Jira attach log to use renamed CamelJiraIssueKey header

### DIFF
--- a/jira/src/main/java/org/apache/camel/example/jira/AttachFileRoute.java
+++ b/jira/src/main/java/org/apache/camel/example/jira/AttachFileRoute.java
@@ -38,7 +38,7 @@ public class AttachFileRoute extends RouteBuilder {
         // change the fields accordinly to your target jira server
         from("file://{{example.jira.upload-directory}}?fileName={{example.jira.upload-file-name}}&noop=true&delay=50000")
                 .setHeader(ISSUE_KEY, () -> issue)
-                .log("  JIRA attach: ${header.camelFileName} to ${headers.IssueKey}")
+                .log("  JIRA attach: ${header.camelFileName} to ${headers.CamelJiraIssueKey}")
                 .to("jira://attach");
 
 


### PR DESCRIPTION
## Summary
- The `JiraConstants.ISSUE_KEY` constant was renamed from `IssueKey` to `CamelJiraIssueKey` (CAMEL-23576), but the log expression in `AttachFileRoute` still referenced the old header name `${headers.IssueKey}`
- This caused the log to print an empty issue key, which fails the `JiraExampleITCase.testAttachFileRoute` assertion that checks for `"JIRA attach: my_file.png to FUSEQE-XXXXX"`

## Test plan
- [x] Verify `JiraConstants.ISSUE_KEY` resolves to `CamelJiraIssueKey`
- [ ] Run TNB examples test pipeline to confirm `JiraExampleITCase.testAttachFileRoute` passes