### PR TITLE
Fix Jira attach route: use Camel property placeholder instead of Supplier

### DIFF
--- a/jira/src/main/java/org/apache/camel/example/jira/AttachFileRoute.java
+++ b/jira/src/main/java/org/apache/camel/example/jira/AttachFileRoute.java
@@ -19,7 +19,6 @@ package org.apache.camel.example.jira;
 import org.apache.camel.builder.RouteBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import static org.apache.camel.component.jira.JiraConstants.ISSUE_KEY;
@@ -29,16 +28,13 @@ public class AttachFileRoute extends RouteBuilder {
 
     private static final Logger LOG = LoggerFactory.getLogger(AttachFileRoute.class);
 
-    @Value("${example.jira.issue-attach}")
-    private String issue;
-
     @Override
     public void configure() {
         LOG.info(" >>>>>>>>>>>>>>>>>>>>> jira example - add attachment");
         // change the fields accordinly to your target jira server
         from("file://{{example.jira.upload-directory}}?fileName={{example.jira.upload-file-name}}&noop=true&delay=50000")
-                .setHeader(ISSUE_KEY, () -> issue)
-                .log("  JIRA attach: ${header.camelFileName} to ${headers.CamelJiraIssueKey}")
+                .setHeader(ISSUE_KEY, simple("{{example.jira.issue-attach}}"))
+                .log("  JIRA attach: ${header.camelFileName} to {{example.jira.issue-attach}}")
                 .to("jira://attach");
 
 


### PR DESCRIPTION
## Summary
- The `@Value` + `Supplier` pattern (`() -> issue`) in `AttachFileRoute` was producing an empty header value, causing `JiraExampleITCase.testAttachFileRoute` to fail
- Replaces `@Value` field injection + Supplier with Camel `{{...}}` property placeholders, which resolve directly from Spring Boot property sources at route creation time
- Also fixes the log expression to use `{{example.jira.issue-attach}}` property placeholder instead of `${headers.IssueKey}` header reference
- Supersedes #339 (which incorrectly assumed `ISSUE_KEY` had been renamed to `CamelJiraIssueKey` in this build, but `camel-jira-4.18.1.redhat-00006` still uses the old `IssueKey` constant)

## Root cause analysis
The `camel-jira-4.18.1.redhat-00006` jar (used in the current productized build) has `JiraConstants.ISSUE_KEY = "IssueKey"` (the CAMEL-23576 rename to `CamelJiraIssueKey` has not landed in this productized version yet). The previous fix (#339) changed the log to `${headers.CamelJiraIssueKey}` which doesn't match. But even the original `${headers.IssueKey}` was failing — the `@Value` Supplier pattern was returning empty for this specific property. Using Camel's native property placeholders bypasses this issue entirely.

## Test plan
- [ ] Run TNB examples test pipeline (`JiraExampleITCase.testAttachFileRoute`)