### PR TITLE
CSB-10013: Fix examples for SB4 — add RH Undertow starter and Artemis…

### DIFF
--- a/platform-http-proxy/pom.xml
+++ b/platform-http-proxy/pom.xml
@@ -55,6 +55,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.redhat.integration</groupId>
+            <artifactId>spring-boot-starter-undertow</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel.springboot</groupId>
             <artifactId>camel-undertow-starter</artifactId>
         </dependency>

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -61,6 +61,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.redhat.integration</groupId>
+            <artifactId>spring-boot-starter-undertow</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel.springboot</groupId>
             <artifactId>camel-undertow-starter</artifactId>
         </dependency>
@@ -86,6 +90,10 @@
             <artifactId>camel-spring-boot-starter</artifactId>
         </dependency>
         <!-- artemis jms pooled connections-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-artemis</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jakarta-client</artifactId>

--- a/salesforce/pom.xml
+++ b/salesforce/pom.xml
@@ -87,6 +87,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.redhat.integration</groupId>
+            <artifactId>spring-boot-starter-undertow</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel.springboot</groupId>
             <artifactId>camel-undertow-starter</artifactId>
         </dependency>


### PR DESCRIPTION
… auto-config

SB4 dropped the standard spring-boot-starter-undertow. The existing camel-undertow-starter provides the Camel Undertow component but not the Spring Boot web container auto-configuration. Add the RH internal starter (com.redhat.integration:spring-boot-starter-undertow) to platform-http-proxy, salesforce, and saga examples.

For saga, also add spring-boot-artemis auto-config module so ArtemisAutoConfiguration activates and spring.artemis.* properties create the ConnectionFactory bean.